### PR TITLE
fix: PR #16 review fixes — torexitnodes package name, remove unused code

### DIFF
--- a/features/providers/alienvault/provider.go
+++ b/features/providers/alienvault/provider.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 	"time"
 
@@ -431,46 +430,4 @@ func indicatorToEntry(indicator *OTXIndicator, source, processID string) (*entri
 			Msg("unsupported indicator type — skipping")
 		return nil, nil
 	}
-}
-
-// HTTPFetcherWithAuth provides an alternative fetcher for AlienVault OTX
-// that uses net/http directly with proper authentication
-type HTTPFetcherWithAuth struct {
-	client    *http.Client
-	userAgent string
-	apiKey    string
-}
-
-func NewHTTPFetcherWithAuth(apiKey string) *HTTPFetcherWithAuth {
-	return &HTTPFetcherWithAuth{
-		client: &http.Client{
-			Timeout: 2 * time.Minute,
-		},
-		userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-		apiKey:    apiKey,
-	}
-}
-
-func (f *HTTPFetcherWithAuth) Fetch(u string) (io.ReadCloser, error) {
-	time.Sleep(1 * time.Second) // Rate limiting — 1 req/sec (confirmed via load testing)
-
-	req, err := http.NewRequest(http.MethodGet, u, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", f.userAgent)
-	req.Header.Set("X-OTX-API-KEY", f.apiKey)
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := f.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		resp.Body.Close()
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
-	}
-
-	return resp.Body, nil
 }

--- a/features/providers/torexitnodes/provider.go
+++ b/features/providers/torexitnodes/provider.go
@@ -1,4 +1,4 @@
-package toreexitnodes
+package torexitnodes
 
 import (
 	"fmt"

--- a/features/providers/torexitnodes/provider_integration_test.go
+++ b/features/providers/torexitnodes/provider_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package toreexitnodes
+package torexitnodes
 
 import (
 	"io"

--- a/features/providers/torexitnodes/provider_test.go
+++ b/features/providers/torexitnodes/provider_test.go
@@ -1,4 +1,4 @@
-package toreexitnodes
+package torexitnodes
 
 import (
 	"strings"


### PR DESCRIPTION
## Summary

Post-merge review fixes for PR #16 (AlienVault OTX provider).

## Changes

### torexitnodes package name mismatch (critical bug)
- Directory: 
- Was:  (extra 'e')
- Now: 
- Fixed in 3 files: provider.go, provider_test.go, provider_integration_test.go

### Remove unused HTTPFetcherWithAuth (dead code)
-  struct was defined but never instantiated
-  was defined but never called
-  method was defined but never called
- Removed ~40 lines of dead code
- Also removed unused  import

## Verification

- `go build` → ✅
- Build passes on clean develop state + fixes applied

## Related

- PR #16: feat(alienvault): implement AlienVault OTX API provider (merged)
