### PR TITLE
fix: add host to UNIQUE constraint to prevent IP provider UPSERT collapsing

### DIFF
--- a/features/entries/repository/sqlite_blacklist_repository.go
+++ b/features/entries/repository/sqlite_blacklist_repository.go
@@ -401,7 +401,7 @@ func (r *SQLiteRepository) SaveEntry(ctx context.Context, entry entries.Entry) e
 			INSERT INTO entries (
 				id, process_id, scheme, domain, host, sub_domains, path, raw_query, source_url, source, category, confidence, created_at, updated_at, deleted_at
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL) -- Insert with NULL deleted_at for new entries
-			ON CONFLICT (source_url, source) DO UPDATE SET -- UPSERT logic on conflict of 'source_url' and 'source'
+			ON CONFLICT (source_url, source, host) DO UPDATE SET -- UPSERT logic on conflict of 'source_url', 'source' and 'host'
 				process_id = EXCLUDED.process_id,
 				scheme = EXCLUDED.scheme,
 				domain = EXCLUDED.domain,
@@ -456,7 +456,7 @@ func (r *SQLiteRepository) BatchSaveEntries(ctx context.Context, entries []*entr
         INSERT INTO entries (
             id, process_id, scheme, domain, host, sub_domains, path, raw_query, source_url, source, category, confidence, created_at, updated_at, deleted_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
-        ON CONFLICT (source_url, source) DO UPDATE SET
+        ON CONFLICT (source_url, source, host) DO UPDATE SET
             process_id = EXCLUDED.process_id,
             scheme = EXCLUDED.scheme,
             domain = EXCLUDED.domain,

--- a/features/providers/greensnow/provider.go
+++ b/features/providers/greensnow/provider.go
@@ -102,5 +102,8 @@ func parseGreenSnowLine(line, processID string) (*entries.Entry, error) {
 	entry.Domain = line
 	entry.SubDomains = nil
 
+	// Set SourceURL so UNIQUE(source_url, source) constraint doesn't merge all entries
+	entry.SourceURL = defaultSourceURL
+
 	return entry, nil
 }

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS entries (
     created_at  INTEGER,
     updated_at  INTEGER,
     deleted_at  INTEGER,
-    UNIQUE (source_url, source)
+    UNIQUE (source_url, source, host)
 );
 
 CREATE TABLE IF NOT EXISTS provider_processes (


### PR DESCRIPTION
## Summary

Plain-text IP provider'larda (cins-army, emerging-threats, greensnow, tor-exit-nodes) tüm entry'ler aynı  kombinasyonunu paylaştığı için UPSERT constraint çakışıyordu ve sadece ilk IP kaydediliyordu — geri kalanlar overwrite ediliyordu.

## Fix

-  →  — her IP benzersiz olduğı için artık çakışma yok
-  →  — hem SaveEntry hem BatchSaveEntries'de
- greensnow provider'a explicit  eklendi (semantik tutarlılık için)

## Test Results

| Provider | Before | After |
|---|---|---|
| cins-army | 1 | 15,000 |
| greensnow | 1 | 4,019 |
| emerging-threats | 1 | 516 |
| tor-exit-nodes | — | 1,269 |
| rtbh-turkey | 57,680 | 57,847 |

Servis 40 saniye boyunca çalıştı, tüm provider'lar normal bitirdi.