### PR TITLE
fix: blocklistde cron + emergingthreats/rtbh sourceurl cleanup

### DIFF
--- a/features/providers/blocklistde/provider.go
+++ b/features/providers/blocklistde/provider.go
@@ -78,7 +78,7 @@ func NewBlocklistDeProvider(cfg *config.Config, collyClient *colly.Collector) ba
 	}
 	cron := opts.Cron
 	if cron == "" {
-		cron = "0 */15 * * * *"
+		cron = "0 */15 * * *"
 	}
 	category := opts.Category
 	if category == "" {

--- a/features/providers/emergingthreats/provider.go
+++ b/features/providers/emergingthreats/provider.go
@@ -50,7 +50,7 @@ func NewEmergingThreatsProvider(cfg *config.Config, collyClient *colly.Collector
 
 	processID := uuid.New().String()
 	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
-		return parseIPList(data, collector, providerName, processID)
+		return parseIPList(data, collector, providerName, sourceURL, processID)
 	}
 
 	bp := base.NewBaseProvider(providerName, sourceURL, category, client, parseFunc)
@@ -97,7 +97,7 @@ func (p *emergingThreatsProvider) Fetch() (io.Reader, error) {
 
 // parseIPList reads plain IPv4 lines and submits each as an Entry.
 // Lines that fail net.ParseIP are silently skipped.
-func parseIPList(data io.Reader, collector entry_collector.Collector, source, processID string) error {
+func parseIPList(data io.Reader, collector entry_collector.Collector, source, sourceURL, processID string) error {
 	scanner := bufio.NewScanner(data)
 
 	var parsed, skipped int
@@ -131,6 +131,7 @@ func parseIPList(data io.Reader, collector entry_collector.Collector, source, pr
 
 		entry.Host = ip.String()
 		entry.Domain = ip.String()
+		entry.SourceURL = sourceURL
 
 		collector.Submit(entry)
 		parsed++

--- a/features/providers/emergingthreats/provider_integration_test.go
+++ b/features/providers/emergingthreats/provider_integration_test.go
@@ -50,7 +50,7 @@ func TestEmergingThreatsIntegration(t *testing.T) {
 	t.Logf("Fetched %d bytes", len(data))
 
 	col := &intgCollector{}
-	err = parseIPList(strings.NewReader(string(data)), col, providerName, "intg-test")
+	err = parseIPList(strings.NewReader(string(data)), col, providerName, "https://rules.emergingthreats.net/test", "intg-test")
 	require.NoError(t, err)
 
 	t.Logf("Fetched and parsed %d entries", len(col.entries))

--- a/features/providers/emergingthreats/provider_test.go
+++ b/features/providers/emergingthreats/provider_test.go
@@ -31,7 +31,7 @@ func TestParseIPList_ValidIPv4(t *testing.T) {
 	input := strings.NewReader("1.2.3.4\n5.6.7.8\n10.20.30.40\n")
 	collector := &testCollector{}
 
-	err := parseIPList(input, collector, testSource, testProcessID)
+	err := parseIPList(input, collector, testSource, "https://emergingthreats.net/test", testProcessID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(collector.entries))
@@ -50,7 +50,7 @@ func TestParseIPList_EmptyInput(t *testing.T) {
 	input := strings.NewReader("")
 	collector := &testCollector{}
 
-	err := parseIPList(input, collector, testSource, testProcessID)
+	err := parseIPList(input, collector, testSource, "https://emergingthreats.net/test", testProcessID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(collector.entries))
@@ -60,7 +60,7 @@ func TestParseIPList_SkipComments(t *testing.T) {
 	input := strings.NewReader("1.2.3.4\n# this is a comment\n5.6.7.8\n")
 	collector := &testCollector{}
 
-	err := parseIPList(input, collector, testSource, testProcessID)
+	err := parseIPList(input, collector, testSource, "https://emergingthreats.net/test", testProcessID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(collector.entries))
@@ -72,7 +72,7 @@ func TestParseIPList_SkipIPv6(t *testing.T) {
 	input := strings.NewReader("1.2.3.4\n::1\n2001:db8::1\n5.6.7.8\n")
 	collector := &testCollector{}
 
-	err := parseIPList(input, collector, testSource, testProcessID)
+	err := parseIPList(input, collector, testSource, "https://emergingthreats.net/test", testProcessID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(collector.entries))
@@ -82,7 +82,7 @@ func TestParseIPList_SkipInvalidLines(t *testing.T) {
 	input := strings.NewReader("1.2.3.4\nnot-an-ip\n\n5.6.7.8\n999.999.999.999\n")
 	collector := &testCollector{}
 
-	err := parseIPList(input, collector, testSource, testProcessID)
+	err := parseIPList(input, collector, testSource, "https://emergingthreats.net/test", testProcessID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(collector.entries))
@@ -92,7 +92,7 @@ func TestParseIPList_BlankLines(t *testing.T) {
 	input := strings.NewReader("1.2.3.4\n\n\n5.6.7.8\n\n")
 	collector := &testCollector{}
 
-	err := parseIPList(input, collector, testSource, testProcessID)
+	err := parseIPList(input, collector, testSource, "https://emergingthreats.net/test", testProcessID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(collector.entries))

--- a/features/providers/rtbh/provider.go
+++ b/features/providers/rtbh/provider.go
@@ -76,6 +76,7 @@ func NewRTBHTurkeyProvider(cfg *config.Config, collyClient *colly.Collector) bas
 			WithProcessID(processID).
 			WithCategory(category).
 			WithIP(ip.String())
+		entry.SourceURL = sourceURL
 
 		return entry, nil
 		})


### PR DESCRIPTION
## Summary

Cleanups found during code review of PR #16 + develop branch.

### Fixes

| # | File | Issue | Fix |
|---|------|--------|-----|
| 1 |  | 6-field Quartz cron `0 */15 * * * *` silently fails | → 5-field `0 */15 * * *` (gocron v3 only accepts standard cron) |
| 2 |  | `parseIPList` missing sourceURL param, entries have empty `source_url` | Added sourceURL param + `entry.SourceURL = sourceURL` |
| 3 |  | `WithIP()` called but SourceURL never set | Added `entry.SourceURL = sourceURL` |
| 4 |  | 6 call sites missing sourceURL arg to `parseIPList` | Updated all call sites |
| 5 |  | Missing sourceURL arg | Updated |

### Verification

```bash
go build ./...  # ✅ clean
go vet ./...    # ✅ clean  
go test ./...   # ✅ all packages pass
```

No breaking changes. All tests updated to match new function signature.