### PR TITLE
fix(server): graceful shutdown, pprof config, bulk parallelization

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
+	"context"
+	"net/http"
+
 	"blacked/features/cache"
 	"blacked/features/entry_collector"
+	"blacked/features/providers"
 	"blacked/features/web"
 	"blacked/internal/config"
 	"blacked/internal/runner"
 
-	"github.com/ory/graceful"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v2"
 )
@@ -46,23 +49,42 @@ func serve(c *cli.Context) (err error) {
 	}
 	log.Debug().Msg("Badger cache initialized")
 
-	server := graceful.WithDefaults(app.Echo.Server)
-	log.Info().Msgf("Starting server on %s", server.Addr)
-
-	if _, err := runner.InitializeRunner(*app.GetProviders()); err != nil {
-		log.Fatal().Err(err).Msg("Failed to initialize runner")
+	// Initialize providers — if this fails, we should NOT start the server
+	if _, err := providers.InitProviders(); err != nil {
+		log.Error().Err(err).Msg("Provider initialization failed — aborting server start")
+		return err
 	}
+	log.Debug().Msg("Providers initialized")
 
 	// Run startup decision engine — determines whether to skip, restore, or fetch each provider
 	if err := runner.RunStartupProviders(c.Context, *app.GetProviders()); err != nil {
 		log.Error().Err(err).Msg("Startup provider evaluation failed, continuing with server startup")
 	}
 
+	if _, err := runner.InitializeRunner(*app.GetProviders()); err != nil {
+		log.Fatal().Err(err).Msg("Failed to initialize runner")
+	}
+
 	defer runner.ShutdownRunner(c.Context)
 
-	if err = graceful.Graceful(server.ListenAndServe, server.Shutdown); err != nil {
-		log.Error().Err(err).Msg("Failed to start server")
-		return err
+	// Graceful shutdown with context timeout using native http.Server.Shutdown()
+	// This properly drains in-flight requests before closing connections
+	server := app.Echo.Server
+	shutdownTimeout := cfg.Server.ShutdownTimeout
+	shutdownCtx, cancel := context.WithTimeout(c.Context, shutdownTimeout)
+	defer cancel()
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Error().Err(err).Msg("Server error")
+		}
+	}()
+
+	log.Info().Msgf("Starting server on %s", server.Addr)
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		log.Error().Err(err).Msg("Graceful shutdown failed, forcing close")
+		return server.Close()
 	}
 
 	log.Info().Msg("Server stopped gracefully.")

--- a/features/web/application.go
+++ b/features/web/application.go
@@ -93,7 +93,11 @@ func NewApplication(cfg *config.ServerConfig) (*Application, error) {
 			return
 		}
 
-		app.ConfigurePprof()
+		if cfg.PprofEnabled {
+			app.ConfigurePprof()
+		} else {
+			log.Info().Msg("pprof disabled via config — /debug/pprof/* endpoints will not be registered")
+		}
 
 		app.providers = providers.GetProviders()
 

--- a/features/web/handlers/v2/query_handler.go
+++ b/features/web/handlers/v2/query_handler.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"blacked/features/bloom"
 	"blacked/features/web/handlers/response"
+	"blacked/internal/collector"
 	"blacked/internal/db"
 	"blacked/internal/query"
 	"net"
@@ -82,6 +83,10 @@ func (h *QueryHandler) Check(c echo.Context) error {
 	if !result.Likely {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// Record business metric
+	if mc, err := collector.GetMetricsCollector(); err == nil {
+		mc.RecordCheck()
+	}
 	return c.JSON(http.StatusOK, result)
 }
 
@@ -124,7 +129,15 @@ func (h *QueryHandler) Hit(c echo.Context) error {
 	}
 
 	if !result.Blocked {
+		// Record business metric — allowed (not blocked)
+		if mc, err := collector.GetMetricsCollector(); err == nil {
+			mc.RecordHit(false)
+		}
 		return c.NoContent(http.StatusNoContent)
+	}
+	// Record business metric — blocked
+	if mc, err := collector.GetMetricsCollector(); err == nil {
+		mc.RecordHit(true)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -150,7 +163,10 @@ func (h *QueryHandler) BulkCheck(c echo.Context) error {
 		return response.ErrorWithDetails(c, http.StatusInternalServerError,
 			"Bulk check failed", err.Error())
 	}
-
+	// Record business metric
+	if mc, err := collector.GetMetricsCollector(); err == nil {
+		mc.RecordBulkCheck()
+	}
 	return c.JSON(http.StatusOK, results)
 }
 
@@ -170,6 +186,16 @@ func (h *QueryHandler) BulkHit(c echo.Context) error {
 		return response.ErrorWithDetails(c, http.StatusInternalServerError,
 			"Bulk hit failed", err.Error())
 	}
-
+	// Record business metric — check if any URL was blocked
+	anyBlocked := false
+	for _, r := range results {
+		if r.Blocked {
+			anyBlocked = true
+			break
+		}
+	}
+	if mc, err := collector.GetMetricsCollector(); err == nil {
+		mc.RecordBulkHit(anyBlocked)
+	}
 	return c.JSON(http.StatusOK, results)
 }

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -36,6 +36,15 @@ type MetricsCollector struct {
 	EntriesParsedTotal  *prometheus.CounterVec // Counter for total blacklist entries parsed from
 	EntriesSavedTotal   *prometheus.CounterVec // Counter for total blacklist entries saved from import
 	ImportErrorsTotal   *prometheus.CounterVec // Counter for total import requests that resulted in errors
+
+	// Business-level metrics for query operations
+	CheckTotal         *prometheus.CounterVec // Counter for total /check requests (bloom only)
+	HitTotal           *prometheus.CounterVec // Counter for total /hit requests (full lookup)
+	HitBlockedTotal    *prometheus.CounterVec // Counter for /hit requests that found a match (blocked)
+	HitAllowedTotal    *prometheus.CounterVec // Counter for /hit requests with no match (allowed)
+	BulkCheckTotal     *prometheus.CounterVec // Counter for total /bulk-check requests
+	BulkHitTotal       *prometheus.CounterVec // Counter for total /bulk-hit requests
+	BulkHitBlockedTotal *prometheus.CounterVec // Counter for /bulk-hit requests with at least one blocked
 }
 
 func GetMetricsCollector() (*MetricsCollector, error) {
@@ -105,6 +114,42 @@ func NewMetricsCollector(providerNames []string) *MetricsCollector {
 				Name: "blacklist_json_import_errors_total",
 				Help: "Total number of import requests that resulted in errors.",
 			}, []string{"provider"}),
+
+			// Business-level query metrics
+			CheckTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_url_check_total",
+				Help: "Total number of /check requests (bloom-only).",
+			}, nil),
+
+			HitTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_hit_total",
+				Help: "Total number of /hit requests (full bloom+DB+score lookup).",
+			}, nil),
+
+			HitBlockedTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_hit_blocked_total",
+				Help: "Total number of /hit requests that found a blocked match.",
+			}, nil),
+
+			HitAllowedTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_hit_allowed_total",
+				Help: "Total number of /hit requests with no blocked match.",
+			}, nil),
+
+			BulkCheckTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_bulk_check_total",
+				Help: "Total number of /bulk-check requests.",
+			}, nil),
+
+			BulkHitTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_bulk_hit_total",
+				Help: "Total number of /bulk-hit requests.",
+			}, nil),
+
+			BulkHitBlockedTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_bulk_hit_blocked_total",
+				Help: "Total number of /bulk-hit requests with at least one blocked URL.",
+			}, nil),
 		}
 		// Populate _mc’s providerMetrics
 		for _, name := range providerNames {
@@ -182,6 +227,36 @@ func (mc *MetricsCollector) IncrementEntriesSaved(providerName string, count int
 
 func (mc *MetricsCollector) IncrementImportErrors(providerName string) {
 	mc.ImportErrorsTotal.With(prometheus.Labels{"provider": providerName}).Inc()
+}
+
+// -- Business query metrics helpers --
+
+// RecordCheck increments the /check request counter.
+func (mc *MetricsCollector) RecordCheck() {
+	mc.CheckTotal.With(nil).Inc()
+}
+
+// RecordHit increments the /hit request counter and whether it was blocked.
+func (mc *MetricsCollector) RecordHit(blocked bool) {
+	mc.HitTotal.With(nil).Inc()
+	if blocked {
+		mc.HitBlockedTotal.With(nil).Inc()
+	} else {
+		mc.HitAllowedTotal.With(nil).Inc()
+	}
+}
+
+// RecordBulkCheck increments the /bulk-check request counter.
+func (mc *MetricsCollector) RecordBulkCheck() {
+	mc.BulkCheckTotal.With(nil).Inc()
+}
+
+// RecordBulkHit increments the /bulk-hit request counter and whether any URL was blocked.
+func (mc *MetricsCollector) RecordBulkHit(anyBlocked bool) {
+	mc.BulkHitTotal.With(nil).Inc()
+	if anyBlocked {
+		mc.BulkHitBlockedTotal.With(nil).Inc()
+	}
 }
 
 // GetAllProviderMetrics - For status tracking (optional, Prometheus has aggregated data directly). Can return less info now.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type ServerConfig struct {
 
 	AllowOrigins []string `koanf:"alloworigins" default:"[]"`
 	HealthCheck  bool     `koanf:"health_check" default:"true"`
+	PprofEnabled bool     `koanf:"pprof_enabled" default:"false"`
 }
 
 func (s *ServerConfig) GetServerURL() string {

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sync"
 )
 
 // BloomChecker is the minimal interface the query service needs from the bloom engine.
@@ -144,29 +145,105 @@ func hostname(urlStr string) string {
 }
 
 // BulkCheck performs fast bloom-only checks for multiple URLs (~0.4ms per URL).
+// Uses parallel goroutines with a semaphore to limit concurrency.
 func (qs *QueryService) BulkCheck(ctx context.Context, urls []string) ([]LikelyResponse, error) {
-	results := make([]LikelyResponse, len(urls))
-	for i, u := range urls {
-		resp, err := qs.Likely(ctx, u)
-		if err != nil {
-			return nil, fmt.Errorf("bulk check url=%s: %w", u, err)
-		}
-		results[i] = *resp
+	return bulkCheckParallel(ctx, qs, urls, 20) // 20 concurrent workers
+}
+
+// bulkCheckParallel runs Likely checks in parallel with bounded concurrency.
+func bulkCheckParallel(ctx context.Context, qs *QueryService, urls []string, concurrency int) ([]LikelyResponse, error) {
+	type result struct {
+		resp LikelyResponse
+		err  error
+		i    int
 	}
-	return results, nil
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	results := make([]result, len(urls))
+	resultChan := make(chan result, len(urls))
+
+	for i, u := range urls {
+		wg.Add(1)
+		go func(u string, i int) {
+			defer wg.Done()
+			sem <- struct{}{}        // acquire
+			defer func() { <-sem }() // release
+
+			resp, err := qs.Likely(ctx, u)
+			resultChan <- result{resp: *resp, err: err, i: i}
+		}(u, i)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	for r := range resultChan {
+		if r.err != nil {
+			return nil, fmt.Errorf("bulk check url=%s: %w", urls[r.i], r.err)
+		}
+		results[r.i] = r
+	}
+
+	// Reassemble in original order
+	out := make([]LikelyResponse, len(urls))
+	for _, r := range results {
+		out[r.i] = r.resp
+	}
+	return out, nil
 }
 
 // BulkHit performs full lookups (bloom + DB + score) for multiple URLs.
+// Uses parallel goroutines with a semaphore to limit concurrency.
 func (qs *QueryService) BulkHit(ctx context.Context, urls []string) ([]QueryResponse, error) {
-	results := make([]QueryResponse, len(urls))
-	for i, u := range urls {
-		resp, err := qs.Hit(ctx, u)
-		if err != nil {
-			return nil, fmt.Errorf("bulk hit url=%s: %w", u, err)
-		}
-		results[i] = *resp
+	return bulkHitParallel(ctx, qs, urls, 20) // 20 concurrent workers
+}
+
+// bulkHitParallel runs Hit checks in parallel with bounded concurrency.
+func bulkHitParallel(ctx context.Context, qs *QueryService, urls []string, concurrency int) ([]QueryResponse, error) {
+	type result struct {
+		resp QueryResponse
+		err  error
+		i    int
 	}
-	return results, nil
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	results := make([]result, len(urls))
+	resultChan := make(chan result, len(urls))
+
+	for i, u := range urls {
+		wg.Add(1)
+		go func(u string, i int) {
+			defer wg.Done()
+			sem <- struct{}{}        // acquire
+			defer func() { <-sem }() // release
+
+			resp, err := qs.Hit(ctx, u)
+			resultChan <- result{resp: *resp, err: err, i: i}
+		}(u, i)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	for r := range resultChan {
+		if r.err != nil {
+			return nil, fmt.Errorf("bulk hit url=%s: %w", urls[r.i], r.err)
+		}
+		results[r.i] = r
+	}
+
+	// Reassemble in original order
+	out := make([]QueryResponse, len(urls))
+	for _, r := range results {
+		out[r.i] = r.resp
+	}
+	return out, nil
 }
 
 // Search performs a filtered search against the entries table.


### PR DESCRIPTION
## Summary
System architecture improvements: graceful shutdown, pprof config, bulk parallelization.

## Changes
1. **Graceful HTTP Shutdown**: `ory/graceful` replaced with native `http.Server.Shutdown(ctx)` using existing ShutdownTimeout (30s default)
2. **pprof Config Flag**: `server.pprof_enabled` (default: false) — production-safe by default
3. **Provider Init Error Handling**: Explicit `providers.InitProviders()` check in serve command
4. **BulkHit/BulkCheck Parallelization**: 20 concurrent workers with semaphore
5. **Business Prometheus Metrics**: url_check, hit, bulk_hit counters

## Testing
- `go build ./...` ✅ PASS

## Files
- `cmd/server.go` — graceful shutdown
- `features/web/application.go` — pprof config
- `features/web/handlers/v2/query_handler.go` — bulk parallelization
- `internal/collector/metrics.go` — business metrics
- `internal/config/config.go` — pprof flag
- `internal/query/service.go` — parallel bulk operations