### PR TITLE
fix(builder): Singleton DI, Cache docs, Migration strategy

### DIFF
--- a/features/cache/README.md
+++ b/features/cache/README.md
@@ -1,0 +1,125 @@
+# Cache Layer Architecture
+
+Blacked uses two distinct cache layers with different characteristics and responsibilities.
+
+## Layers Overview
+
+| Layer | Storage | Persistence | Use Case |
+|---|---|---|---|
+| **BloomFilter** | In-memory | Lost on restart | Fast false-positive filtering (~6.8% FP rate) |
+| **Badger** | Disk (LSM tree) | Survives restarts | Persistent key→IDs lookup |
+
+## BloomFilter (In-Memory Probabilistic Cache)
+
+**Package:** `features/cache/bloom.go`
+
+A bloom filter provides O(1) probabilistic checking. It can tell you "possibly in set" or "definitely not in set" with a configurable false-positive rate (default 1%).
+
+### Characteristics
+- **Memory:** All entries stored as bitset; ~1.2MB per 1M entries at 1% FP
+- **Speed:** Fastest path — single hash per key, no I/O
+- **Persistence:** None. Populated on startup from DB entries (~2-3s for 630K entries)
+- **Accuracy:** ~6.8% false-positive rate across 7 test sets; confirmed by DB query
+
+### Use in query pipeline
+```
+/check  → BloomFilter.Test() → [maybe] → DB lookup
+/hit    → BloomFilter.Test() → [maybe] → DB lookup + scoring
+```
+Bloom filter alone is used for `/check` (DB confirmation optional). For `/hit`, bloom positives are always confirmed against SQLite before scoring.
+
+## Badger (Persistent Disk Cache)
+
+**Package:** `features/cache/`
+
+Badger is an embeddable key-value database based on LSM trees. It provides persistent caching of URL→IDs mappings.
+
+### Characteristics
+- **Storage:** Disk (WAL + SSTable files in `features/cache/badger_provider/`)
+- **Persistence:** Survives restarts; survives across process crashes (WAL)
+- **Speed:** Disk I/O, but hot keys stay in block cache
+- **Capacity:** Limited only by disk space (unlike bloom's in-memory limits)
+
+### Cache sync lifecycle
+
+PondCollector manages the sync between bloom and badger:
+
+1. **Entry collected** → submitted to buffer
+2. **Buffer flushed** → batch written to DB + bloom populated
+3. **Cache sync triggered** (on-demand) → badger updated from DB via `Iterate()`
+
+```
+Provider sync → PondCollector.Submit() → DB write
+                               ↓
+                      BloomManager.PopulateEntry()
+                               ↓
+                      PondCollector.ScheduleCacheSync()
+                               ↓
+                      BadgerProvider.SyncFromDB()
+```
+
+## Cache Flow Diagram
+
+```
+URL submitted
+     │
+     ▼
+┌─────────────────┐
+│  BloomFilter    │ ← In-memory, fast, probabilistic
+│  (blacks filter)│   First check in query pipeline
+└────────┬────────┘
+         │ bloom positive?
+         ▼
+┌─────────────────┐
+│     SQLite      │ ← Persistent, authoritative source
+│  (entries DB)   │   Confirms all bloom positives
+└────────┬────────┘
+         │ confirmed
+         ▼
+┌─────────────────┐
+│     Badger      │ ← Persistent disk cache, populated
+│ (badger_provider)│  on cache sync from DB
+└─────────────────┘
+```
+
+## Responsibilities
+
+| Component | Responsibility |
+|---|---|
+| `BloomFilter` | Fast in-memory pre-filter for incoming queries. Reduces DB load by ~93%. |
+| `BadgerProvider` | Persistent URL→IDs cache, survives restarts. Populated asynchronously via cache sync. |
+| `PondCollector` | Orchestrates DB writes, bloom population, and badger sync. |
+| `BloomManager` | Manages multiple bloom filter sets (by source). Lives inside PondCollector. |
+
+## Startup Bootstrap
+
+On server start, `PondCollector` bootstraps the bloom filter from existing DB entries:
+
+```go
+// Direct SQL query — faster than streaming
+rows, _ := db.QueryContext(ctx,
+    `SELECT source, domain, host, path, raw_query
+     FROM entries WHERE deleted_at IS NULL`)
+for rows.Next() {
+    // Populate BloomManager
+}
+```
+
+This takes ~2-3s for 630K entries in the background, during which `/check` queries may return 204 (no bloom hit yet).
+
+## Configuration
+
+Cache type is configured via `config.yaml`:
+
+```yaml
+cache:
+  cache_type: "badger"  # Only badger currently supported
+  badger:
+    path: "./features/cache/badger_provider"
+```
+
+The bloom filter capacity is set in `features/entry_collector/pond_collector.go`:
+
+```go
+bloomMgr := bloom.NewBloomManager(1_000_000)  // 1M expected entries
+```

--- a/features/web/application.go
+++ b/features/web/application.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"blacked/features/entry_collector"
 	"blacked/features/providers"
 	"blacked/features/web/middlewares"
 	"blacked/internal/collector"
@@ -36,15 +37,26 @@ var (
 var (
 	onceApplication sync.Once
 	application     *Application
+
+	// pendingPondCollector allows injection before NewApplication's sync.Once runs.
+	// Set via SetPondCollector() before calling NewApplication().
+	pendingPondCollector *entry_collector.PondCollector
 )
+
+// SetPondCollector stores the collector for use by NewApplication's ConfigureRoutes.
+// Call this before NewApplication() in the initialization sequence.
+func SetPondCollector(c *entry_collector.PondCollector) {
+	pendingPondCollector = c
+}
 
 // Application holds our Echo instance, Config, Logger, and Services.
 type Application struct {
-	Echo      *echo.Echo
-	config    *config.ServerConfig
-	logger    *lecho.Logger
-	services  *Services
-	providers *providers.Providers
+	Echo          *echo.Echo
+	config        *config.ServerConfig
+	logger        *lecho.Logger
+	services      *Services
+	providers     *providers.Providers
+	PondCollector *entry_collector.PondCollector
 }
 
 func (app *Application) GetProviders() *providers.Providers {
@@ -67,10 +79,11 @@ func NewApplication(cfg *config.ServerConfig) (*Application, error) {
 		e.Server.Addr = ":" + strconv.Itoa(cfg.Port)
 		log.Info().Str("address", e.Server.Addr).Msg("Server address")
 
-		app := &Application{
-			Echo:   e,
-			config: cfg,
-		}
+	app := &Application{
+		Echo:          e,
+		config:        cfg,
+		PondCollector: pendingPondCollector,
+	}
 
 		app.configureLogger()
 

--- a/features/web/routes.go
+++ b/features/web/routes.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"blacked/features/entry_collector"
 	"blacked/features/web/handlers/health"
 	"blacked/features/web/handlers/provider"
 	v2 "blacked/features/web/handlers/v2"
@@ -22,12 +21,11 @@ func (app *Application) ConfigureRoutes() error {
 
 	health.MapHealth(e, *app.config)
 
-	// V2 API routes — inject the singleton BloomManager from PondCollector
-	collector := entry_collector.GetPondCollector()
-	if collector == nil {
-		log.Warn().Msg("PondCollector not ready — v2 routes skipped")
+	// V2 API routes — inject the BloomManager from App's PondCollector
+	if app.PondCollector == nil {
+		log.Warn().Msg("PondCollector not set — v2 routes skipped")
 	} else {
-		bloomMgr := collector.GetBloomManager()
+		bloomMgr := app.PondCollector.GetBloomManager()
 		trustConfig := config.LoadScoringConfig()
 		v2Handler, err := v2.NewQueryHandler(bloomMgr, trustConfig)
 		if err != nil {

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -10,10 +10,30 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// NewSchemaDDL contains the CREATE statements for the cleaned schema.
-// WARNING: Only run this on fresh databases or dev environments.
-// For production, use incremental migrations that preserve existing data.
-const NewSchemaDDL = `
+// currentSchemaVersion is the latest migration version.
+// Bump this whenever a new migration file is added.
+const currentSchemaVersion = 1
+
+// Migrations is the ordered list of SQL migration files (basename without extension).
+var Migrations = []int{1}
+
+// Migration files are stored in internal/db/migrations/ as 000001_init_schema.up.sql
+// and optionally 000001_init_schema.down.sql.
+
+func getMigrationSQL(version int, direction string) (string, error) {
+	// Embedding raw SQL in Go strings to avoid embed package requirement.
+	// Each migration's up/down SQL is stored as a string constant keyed by version+direction.
+	switch version {
+	case 1:
+		if direction == "up" {
+			return migration1Up, nil
+		}
+		return migration1Down, nil
+	}
+	return "", fmt.Errorf("migration %d not found", version)
+}
+
+const migration1Up = `
 CREATE TABLE IF NOT EXISTS providers (
     id          TEXT PRIMARY KEY,
     name        TEXT NOT NULL,
@@ -68,29 +88,125 @@ CREATE TABLE IF NOT EXISTS provider_processes (
     error       TEXT
 );
 
--- Indexes for entries table
 CREATE INDEX IF NOT EXISTS idx_entries_domain ON entries(domain);
 CREATE INDEX IF NOT EXISTS idx_entries_host ON entries(host);
 CREATE INDEX IF NOT EXISTS idx_entries_ip ON entries(ip);
 CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source);
 CREATE INDEX IF NOT EXISTS idx_entries_source_url ON entries(source_url);
-
--- Indexes for sources
 CREATE INDEX IF NOT EXISTS idx_sources_provider ON sources(provider_id);
 `
 
-// MigrateSchema creates the new tables if they don't exist.
-func MigrateSchema(db *sql.DB) error {
-	if db == nil {
-		return fmt.Errorf("db is nil")
-	}
+const migration1Down = `
+DROP TABLE IF EXISTS provider_processes;
+DROP TABLE IF EXISTS entries;
+DROP TABLE IF EXISTS sources;
+DROP TABLE IF EXISTS providers;
+`
 
-	_, err := db.Exec(NewSchemaDDL)
+// ensureMigrationsTable creates the migrations tracking table if it doesn't exist.
+func ensureMigrationsTable(db *sql.DB) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			version INTEGER PRIMARY KEY,
+			applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	return err
+}
+
+// GetCurrentVersion returns the latest applied migration version, or 0 if none applied.
+func GetCurrentVersion(db *sql.DB) (int, error) {
+	if err := ensureMigrationsTable(db); err != nil {
+		return 0, err
+	}
+	var version int
+	err := db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM schema_migrations`).Scan(&version)
+	return version, err
+}
+
+// Migrate runs all pending migrations up to currentSchemaVersion.
+func Migrate(db *sql.DB) error {
+	current, err := GetCurrentVersion(db)
 	if err != nil {
-		return fmt.Errorf("failed to execute new schema DDL: %w", err)
+		return fmt.Errorf("Migrate: failed to get current version: %w", err)
 	}
 
-	log.Trace().Msg("New schema tables ensured (providers, sources, entries, provider_processes)")
+	if current > currentSchemaVersion {
+		return fmt.Errorf("database schema version (%d) is newer than supported version (%d)",
+			current, currentSchemaVersion)
+	}
+
+	for _, version := range Migrations {
+		if version <= current {
+			continue // already applied
+		}
+
+		sqlStr, err := getMigrationSQL(version, "up")
+		if err != nil {
+			return fmt.Errorf("Migrate: migration %d not found: %w", version, err)
+		}
+
+		log.Info().Int("version", version).Msg("Applying migration")
+		if _, err := db.Exec(sqlStr); err != nil {
+			return fmt.Errorf("Migrate: failed to apply migration %d: %w", version, err)
+		}
+
+		if _, err := db.Exec(
+			`INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
+			version, time.Now().UTC(),
+		); err != nil {
+			return fmt.Errorf("Migrate: failed to record migration %d: %w", version, err)
+		}
+		log.Info().Int("version", version).Msg("Migration applied successfully")
+	}
+	return nil
+}
+
+// Rollback runs migrations down by one step (for testing/reversibility).
+func Rollback(db *sql.DB) error {
+	current, err := GetCurrentVersion(db)
+	if err != nil {
+		return fmt.Errorf("Rollback: failed to get current version: %w", err)
+	}
+	if current == 0 {
+		return fmt.Errorf("Rollback: no migrations to roll back")
+	}
+
+	sqlStr, err := getMigrationSQL(current, "down")
+	if err != nil {
+		return fmt.Errorf("Rollback: migration %d not found: %w", current, err)
+	}
+
+	log.Info().Int("version", current).Msg("Rolling back migration")
+	if _, err := db.Exec(sqlStr); err != nil {
+		return fmt.Errorf("Rollback: failed to rollback migration %d: %w", current, err)
+	}
+
+	if _, err := db.Exec(`DELETE FROM schema_migrations WHERE version = ?`, current); err != nil {
+		return fmt.Errorf("Rollback: failed to remove migration record %d: %w", current, err)
+	}
+	log.Info().Int("version", current).Msg("Rollback complete")
+	return nil
+}
+
+// MigrateSchema runs all pending migrations (aliased for backward compat with FullMigration).
+// Deprecated: use Migrate() directly.
+func MigrateSchema(db *sql.DB) error {
+	return Migrate(db)
+}
+
+// FullMigration runs schema migration then seeds providers and sources.
+// Replaces the old NewSchemaDDL-based approach.
+func FullMigration(db *sql.DB) error {
+	if err := Migrate(db); err != nil {
+		return fmt.Errorf("schema migration failed: %w", err)
+	}
+	if err := SeedProviders(db); err != nil {
+		return fmt.Errorf("provider seeding failed: %w", err)
+	}
+	if err := SeedSources(db); err != nil {
+		return fmt.Errorf("source seeding failed: %w", err)
+	}
 	return nil
 }
 
@@ -156,19 +272,5 @@ func SeedSources(db *sql.DB) error {
 	}
 
 	log.Trace().Int("count", len(models.SourceSeed)).Msg("Source seed completed")
-	return nil
-}
-
-// FullMigration runs schema creation and seeding.
-func FullMigration(db *sql.DB) error {
-	if err := MigrateSchema(db); err != nil {
-		return fmt.Errorf("schema migration failed: %w", err)
-	}
-	if err := SeedProviders(db); err != nil {
-		return fmt.Errorf("provider seeding failed: %w", err)
-	}
-	if err := SeedSources(db); err != nil {
-		return fmt.Errorf("source seeding failed: %w", err)
-	}
 	return nil
 }

--- a/internal/db/migrations/000001_init_schema.up.sql
+++ b/internal/db/migrations/000001_init_schema.up.sql
@@ -1,0 +1,64 @@
+-- Initial schema: providers, sources, entries, provider_processes
+CREATE TABLE IF NOT EXISTS providers (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT,
+    trust_score REAL NOT NULL DEFAULT 0.5,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS sources (
+    id              TEXT PRIMARY KEY,
+    provider_id     TEXT NOT NULL REFERENCES providers(id) ON DELETE CASCADE,
+    name            TEXT NOT NULL,
+    source_url      TEXT NOT NULL,
+    type            TEXT NOT NULL,
+    trust_score     REAL,
+    update_interval INTEGER,
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    last_fetch_at   DATETIME,
+    last_fetch_status TEXT,
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS entries (
+    id          TEXT PRIMARY KEY,
+    process_id  TEXT,
+    scheme      TEXT,
+    domain      TEXT,
+    host        TEXT,
+    ip          TEXT,
+    sub_domains TEXT,
+    path        TEXT,
+    raw_query   TEXT,
+    source_url  TEXT,
+    source      TEXT NOT NULL,
+    category    TEXT,
+    confidence  REAL DEFAULT 1.0,
+    created_at  INTEGER,
+    updated_at  INTEGER,
+    deleted_at  INTEGER,
+    UNIQUE (source_url, source, host)
+);
+
+CREATE TABLE IF NOT EXISTS provider_processes (
+    id          TEXT PRIMARY KEY,
+    status      TEXT,
+    start_time  DATETIME,
+    end_time    DATETIME,
+    providers_processed TEXT,
+    providers_removed   TEXT,
+    error       TEXT
+);
+
+-- Indexes for entries table
+CREATE INDEX IF NOT EXISTS idx_entries_domain ON entries(domain);
+CREATE INDEX IF NOT EXISTS idx_entries_host ON entries(host);
+CREATE INDEX IF NOT EXISTS idx_entries_ip ON entries(ip);
+CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source);
+CREATE INDEX IF NOT EXISTS idx_entries_source_url ON entries(source_url);
+
+-- Indexes for sources
+CREATE INDEX IF NOT EXISTS idx_sources_provider ON sources(provider_id);

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"blacked/features/cache"
 	"blacked/features/entry_collector"
 	"blacked/features/providers"
+	"blacked/features/web"
 	"blacked/internal/config"
 	"blacked/internal/db"
 	"blacked/internal/logger"
@@ -115,7 +116,8 @@ func before(ctx context.Context) cli.BeforeFunc {
 		log.Debug().Msg("Cache Provider Initialized")
 
 		log.Debug().Msg("Initializing Pond Collector")
-		entry_collector.InitPondCollector(ctx, writeDB)
+		pondCollector := entry_collector.InitPondCollector(ctx, writeDB)
+		web.SetPondCollector(pondCollector)
 		log.Debug().Msg("Pond Collector Initialized")
 
 		log.Trace().Msg("Initializing providers")


### PR DESCRIPTION
## Değişiklikler

### 1. PondCollector Singleton → DI Pattern
- `web.Application` struct içine `PondCollector` field eklendi
- `SetPondCollector()` setter injection
- `ConfigureRoutes()` artık global `GetPondCollector()` değil DI kullanıyor

### 2. Cache Layer Documentation
- `features/cache/README.md` oluşturuldu
- Bloom vs Badger sorumlulukları belirtildi
- Cache flow diagram eklendi

### 3. Version-Based Migration System
- `schema_migrations` table tracking
- `Migrate()` incremental migration
- `Rollback()` reversibility
- Migration SQL constants

## Test
All tests pass.