### PR TITLE
fix(db): add automatic WAL checkpointing to prevent unbounded growth

### DIFF
--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -227,5 +227,11 @@ func connectSQLite(dataSourceName string, maxOpen, maxIdle int) (*sql.DB, error)
 		log.Warn().Err(err).Msg("Failed to set busy timeout")
 	}
 
+	// Enable automatic WAL checkpointing every 1000 pages
+	// This prevents the WAL file from growing unbounded
+	if _, err := db.Exec("PRAGMA wal_autocheckpoint = 1000"); err != nil {
+		log.Warn().Err(err).Msg("Failed to set wal_autocheckpoint")
+	}
+
 	return db, nil
 }


### PR DESCRIPTION
## Problem
SQLite WAL mode was enabled in `internal/db/connect.go` via DSN parameter, but no automatic checkpointing was configured. This caused the WAL file to grow unbounded in long-running processes.

## Solution
Added `PRAGMA wal_autocheckpoint = 1000` in the `connectSQLite` function. This triggers automatic checkpointing every 1000 pages (approximately 4MB), preventing the WAL file from growing indefinitely.

## Changes
- Modified `internal/db/connect.go`: Added WAL autocheckpoint pragma after other SQLite optimizations
- Checkpoint threshold: 1000 pages (~4MB)

## Testing
- Existing tests continue to pass (pre-existing lint errors in connect.go are unrelated to this change)
- The change applies to all database connections (read-only, read-write, and default)

## Impact
- Prevents disk space issues from unbounded WAL growth
- Maintains WAL mode benefits (concurrent reads during writes)
- Minimal performance impact - checkpointing is a standard SQLite operation