### PR TITLE
Fix: AlienVault API 403 and nil CollyClient crash

### DIFF
--- a/features/providers/alienvault/provider.go
+++ b/features/providers/alienvault/provider.go
@@ -140,22 +140,17 @@ for {
 				time.Sleep(sleepDuration)
 			}
 
-			// Build a fresh collector for each attempt. Cloning the parent's collector
-			// preserves global state (visited URLs, rate limiters) across retries, causing
-			// "already visited" errors on the 2nd attempt. Fresh collectors avoid this.
-			var c *colly.Collector
-			if attempt == 0 && p.CollyClient != nil {
-				c = p.CollyClient.Clone()
-			} else {
-				c = colly.NewCollector()
-			}
+			// Always use fresh collector for OTX API — clone inherits browser UA from parent,
+			// which OTX rejects with 403. Fresh collector with explicit headers works reliably.
+			c := colly.NewCollector()
 			c.MaxBodySize = 10 * 1024 * 1024
 			c.AllowedDomains = []string{} // disable domain filter for API server
 
-			// Set OTX API key header
+			// Set OTX API key header (API endpoint requires non-browser User-Agent)
 			c.OnRequest(func(r *colly.Request) {
 				r.Headers.Set("X-OTX-API-KEY", p.apiKey)
 				r.Headers.Set("Accept", "application/json")
+				r.Headers.Set("User-Agent", "blacked/1.0")
 			})
 
 			body = nil

--- a/features/providers/base/base_provider.go
+++ b/features/providers/base/base_provider.go
@@ -164,6 +164,11 @@ func (b *BaseProvider) FetchWithContext(ctx context.Context) (io.Reader, error) 
 		var responseBody []byte
 		var fetchErr error
 
+		// Nil check for CollyClient — some providers (like AlienVault) use fresh collectors
+		if b.CollyClient == nil {
+			log.Error().Str("provider", b.Name).Msg("CollyClient is nil — cannot fetch")
+			return nil, ErrFetchingSource
+		}
 		c := b.CollyClient.Clone()
 		
 		// Apply timeout from resilience config


### PR DESCRIPTION
- **AlienVault**: Use fresh collector instead of Clone() to avoid inheriting browser User-Agent which OTX API rejects with 403. OTX requires non-browser UA for API calls.
- **Base provider**: Add nil check for CollyClient to prevent crash when providers use fresh collectors.
- **Config**: Pihole provider disabled (not suitable for this project).

Test: curl with X-OTX-API-KEY header works, but Colly was inheriting browser UA from config.