### PR TITLE
fix: Update OpenPhish feed URL to GitHub public feed

### DIFF
--- a/features/providers/openphish/openphish_feed.go
+++ b/features/providers/openphish/openphish_feed.go
@@ -26,7 +26,7 @@ func NewOpenPhishFeedProvider(cfg *config.Config, collyClient *colly.Collector) 
 
 	sourceURL := opts.SourceURL
 	if sourceURL == "" {
-		sourceURL = "https://openphish.com/feed.txt"
+		sourceURL = "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt"
 	}
 	cron := opts.Cron
 	if cron == "" {

--- a/features/tests/blacked_integration_test.go
+++ b/features/tests/blacked_integration_test.go
@@ -126,7 +126,7 @@ func seedSources(t testing.TB, db *sql.DB) {
 		{"src-phishtank", "test-phishtank", "PhishTank Source", "https://phishtank.org/files/valid/", "phishtank", 0.70, 7200},
 		{"src-oisd-nsfw", "test-oisd-nsfw", "OISD NSFW Source", "https://nsfw.oisd.nl/", "oisd_nsfw", 0.65, 86400},
 		{"src-oisd-big", "test-oisd-big", "OISD Big Source", "https://big.oisd.nl/", "oisd_big", 0.65, 86400},
-		{"src-openphish", "test-openphish", "OpenPhish Source", "https://openphish.com/feed.txt", "openphish", 0.70, 1800},
+		{"src-openphish", "test-openphish", "OpenPhish Source", "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt", "openphish", 0.70, 1800},
 	}
 	for _, s := range sources {
 		_, err := db.Exec(`

--- a/internal/db/models/source.go
+++ b/internal/db/models/source.go
@@ -43,7 +43,7 @@ var SourceSeed = []Source{
 	{ID: "oisd-big", ProviderID: "oisd", Name: "OISD Big", SourceURL: "https://big.oisd.nl/domainswild2", Type: SourceTypeFlat, Enabled: true, UpdateInterval: sql.NullInt64{Int64: 86400, Valid: true}},       // daily
 	{ID: "oisd-nsfw", ProviderID: "oisd", Name: "OISD NSFW", SourceURL: "https://nsfw.oisd.nl/domainswild2", Type: SourceTypeFlat, Enabled: true, UpdateInterval: sql.NullInt64{Int64: 86400, Valid: true}},   // daily
 	{ID: "urlhaus-online", ProviderID: "abuse-ch", Name: "URLHaus Online", SourceURL: "https://urlhaus.abuse.ch/downloads/text/", Type: SourceTypeFlat, Enabled: true, UpdateInterval: sql.NullInt64{Int64: 7200, Valid: true}},    // 2 hours
-	{ID: "openphish-feed", ProviderID: "openphish", Name: "OpenPhish Feed", SourceURL: "https://openphish.com/feed.txt", Type: SourceTypeFlat, Enabled: true, UpdateInterval: sql.NullInt64{Int64: 14400, Valid: true}},     // 4 hours
+	{ID: "openphish-feed", ProviderID: "openphish", Name: "OpenPhish Feed", SourceURL: "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt", Type: SourceTypeFlat, Enabled: true, UpdateInterval: sql.NullInt64{Int64: 14400, Valid: true}},     // 4 hours
 	{ID: "phishtank-online-valid", ProviderID: "phishtank", Name: "PhishTank Online Valid", SourceURL: "https://data.phishtank.com/data/online-valid.json", Type: SourceTypeJSON, Enabled: true, UpdateInterval: sql.NullInt64{Int64: 14400, Valid: true}}, // 4 hours
 	{ID: "spamhaus-drop", ProviderID: "spamhaus", Name: "Spamhaus DROP", SourceURL: "https://www.spamhaus.org/drop/drop.txt", Type: SourceTypeFlat, Enabled: true, UpdateInterval: sql.NullInt64{Int64: 86400, Valid: true}}, // daily
 }

--- a/internal/testutil/init.go
+++ b/internal/testutil/init.go
@@ -44,7 +44,7 @@ func defaultProviderConfigs() map[string]*config.ProviderOptions {
 		},
 		"openphish-feed": {
 			Enabled:         boolPtr(false),
-			SourceURL:       "https://openphish.com/feed.txt",
+			SourceURL:       "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt",
 			Cron:            "30 */4 * * *",
 			Category:        "phishing",
 			ParserWorkers:   4,


### PR DESCRIPTION
## Problem
OpenPhish free feed URL changed. Old URL `https://openphish.com/feed.txt` no longer works as expected.

## Solution
Updated to GitHub public feed:
```
NEW: https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt
```

## Changes
| File | Update |
|------|--------|
| `internal/db/models/source.go` | DB seed URL |
| `internal/testutil/init.go` | Test config URL |
| `features/providers/openphish/openphish_feed.go` | Default fallback URL |
| `features/tests/blacked_integration_test.go` | Integration test source |

## Verification
- `go build ./...` ✓
- `go test ./features/providers/openphish/...` ✓ (300 URLs parsed)
- Feed fetches successfully from GitHub

## Notes
- Same format: plain text, one URL per line
- Feed updates every 12 hours (we check every 4h, which is fine)