### PR TITLE
fix: pass processID from provider to ParseLinesParallel

### DIFF
--- a/features/providers/alienvault/provider.go
+++ b/features/providers/alienvault/provider.go
@@ -14,7 +14,6 @@ import (
 	"blacked/internal/config"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -82,8 +81,7 @@ func NewAlienvaultProvider(cfg *config.Config, collyClient *colly.Collector) bas
 		client.MaxBodySize = 10 * 1024 * 1024 // 10 MB
 	}
 
-	processID := uuid.New().String()
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
 		raw, err := io.ReadAll(data)
 		if err != nil {
 			return fmt.Errorf("read alienvault data: %w", err)

--- a/features/providers/base/base_provider.go
+++ b/features/providers/base/base_provider.go
@@ -63,12 +63,12 @@ type BaseProvider struct {
 	CronSchedule     string
 	RateLimit        time.Duration
 	Repository       repository.BlacklistRepository
-	ParseFunction    func(io.Reader, entry_collector.Collector) error
+	ParseFunction    func(io.Reader, entry_collector.Collector, string) error
 	ResilienceConfig *resilience.ProviderResilienceConfig
 }
 
 // NewBaseProvider creates a new BaseProvider
-func NewBaseProvider(name, sourceURL, category string, collyClient *colly.Collector, parseFunc func(io.Reader, entry_collector.Collector) error) *BaseProvider {
+func NewBaseProvider(name, sourceURL, category string, collyClient *colly.Collector, parseFunc func(io.Reader, entry_collector.Collector, string) error) *BaseProvider {
 	p := &BaseProvider{
 		Name:        name,
 		SourceURL:   sourceURL,
@@ -231,7 +231,14 @@ func (b *BaseProvider) Parse(data io.Reader) error {
 		return ErrParsingData
 	}
 
-	err := b.ParseFunction(data, collector)
+	// Get the processID that was set by process.go
+	if b.ProcessID == nil {
+		log.Error().Str("provider", b.Name).Msg("ProcessID not set")
+		return ErrProcessIDNotSet
+	}
+	strProcessID := b.ProcessID.String()
+
+	err := b.ParseFunction(data, collector, strProcessID)
 	if err != nil {
 		log.Err(err).Str("provider", b.Name).Msg("Error parsing data")
 		return ErrParsingData

--- a/features/providers/base/parallel_parser.go
+++ b/features/providers/base/parallel_parser.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -107,10 +106,13 @@ type LineProcessor func(line string, processID string) (*entries.Entry, error)
 
 // ParseLinesParallel reads lines from a reader and processes them in parallel
 // This is optimized for large files with millions of lines
+// processID must be passed to ensure entries are written with the same processID
+// that will be used for RemoveOlderInsertions later
 func ParseLinesParallel(
 	data io.Reader,
 	collector entry_collector.Collector,
 	providerName string,
+	processID string,
 	numWorkers int,
 	batchSize int,
 	processor LineProcessor,
@@ -125,7 +127,6 @@ func ParseLinesParallel(
 		batchSize = 1000
 	}
 
-	processID := uuid.New().String()
 	stopExecTrace := maybeStartExecTrace(providerName, processID)
 	defer stopExecTrace()
 

--- a/features/providers/blocklistde/provider.go
+++ b/features/providers/blocklistde/provider.go
@@ -14,7 +14,6 @@ import (
 	"blacked/internal/config"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -87,8 +86,7 @@ func NewBlocklistDeProvider(cfg *config.Config, collyClient *colly.Collector) ba
 
 	client := base.BuildCollyClientForProvider(collyClient, opts)
 
-	processID := uuid.New().String()
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
 		raw, err := io.ReadAll(data)
 		if err != nil {
 			return fmt.Errorf("read blocklistde data: %w", err)

--- a/features/providers/cinsarmy/provider.go
+++ b/features/providers/cinsarmy/provider.go
@@ -12,7 +12,6 @@ import (
 	"blacked/internal/config"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -49,8 +48,7 @@ func NewCINSArmyProvider(cfg *config.Config, collyClient *colly.Collector) base.
 		category = "scanner"
 	}
 
-	processID := uuid.New().String()
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
 		raw, err := io.ReadAll(data)
 		if err != nil {
 			return fmt.Errorf("read cins data: %w", err)

--- a/features/providers/emergingthreats/provider.go
+++ b/features/providers/emergingthreats/provider.go
@@ -12,7 +12,6 @@ import (
 	"blacked/internal/config"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -48,8 +47,7 @@ func NewEmergingThreatsProvider(cfg *config.Config, collyClient *colly.Collector
 
 	client := base.BuildCollyClientForProvider(collyClient, opts)
 
-	processID := uuid.New().String()
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
 		return parseIPList(data, collector, providerName, sourceURL, processID)
 	}
 

--- a/features/providers/greensnow/provider.go
+++ b/features/providers/greensnow/provider.go
@@ -59,8 +59,8 @@ func NewGreenSnowProvider(cfg *config.Config, collyClient *colly.Collector) base
 
 	client := base.BuildCollyClientForProvider(collyClient, opts)
 
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
-		return base.ParseLinesParallel(data, collector, providerName, workers, batchSize,
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
+		return base.ParseLinesParallel(data, collector, providerName, processID, workers, batchSize,
 			func(line, processID string) (*entries.Entry, error) {
 				return parseGreenSnowLine(line, processID)
 			})

--- a/features/providers/oisd/oisd_big.go
+++ b/features/providers/oisd/oisd_big.go
@@ -49,8 +49,8 @@ func NewOISDBigProvider(cfg *config.Config, collyClient *colly.Collector) base.P
 
 	client := base.BuildCollyClientForProvider(collyClient, opts)
 
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
-		return base.ParseLinesParallel(data, collector, providerName, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
+		return base.ParseLinesParallel(data, collector, providerName, processID, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
 			line = strings.TrimSpace(line)
 			if line == "" || strings.HasPrefix(line, "#") {
 				return nil, nil

--- a/features/providers/oisd/oisd_nsfw.go
+++ b/features/providers/oisd/oisd_nsfw.go
@@ -49,8 +49,8 @@ func NewOISDNSFWProvider(cfg *config.Config, collyClient *colly.Collector) base.
 
 	client := base.BuildCollyClientForProvider(collyClient, opts)
 
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
-		return base.ParseLinesParallel(data, collector, providerName, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
+		return base.ParseLinesParallel(data, collector, providerName, processID, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
 			line = strings.TrimSpace(line)
 			if line == "" || strings.HasPrefix(line, "#") {
 				return nil, nil

--- a/features/providers/openphish/openphish_feed.go
+++ b/features/providers/openphish/openphish_feed.go
@@ -44,8 +44,8 @@ func NewOpenPhishFeedProvider(cfg *config.Config, collyClient *colly.Collector) 
 
 	client := base.BuildCollyClientForProvider(collyClient, opts)
 
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
-		return base.ParseLinesParallel(data, collector, providerName, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
+		return base.ParseLinesParallel(data, collector, providerName, processID, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
 			line = strings.TrimSpace(line)
 			if line == "" || strings.HasPrefix(line, "#") {
 				return nil, nil

--- a/features/providers/phishtank/online_valid.go
+++ b/features/providers/phishtank/online_valid.go
@@ -9,7 +9,6 @@ import (
 	"io"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -57,9 +56,8 @@ func NewPhishTankProvider(cfg *config.Config, collyClient *colly.Collector) base
 
 	client := base.BuildCollyClientForProvider(collyClient, opts)
 
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
 		var phishEntries []PhishTankEntry
-		id := uuid.New().String()
 
 		decoder := json.NewDecoder(data)
 		if err := decoder.Decode(&phishEntries); err != nil {
@@ -83,7 +81,7 @@ func NewPhishTankProvider(cfg *config.Config, collyClient *colly.Collector) base
 			}
 
 			return entry, nil
-		}, id)
+		}, processID)
 	}
 
 	provider := base.NewBaseProvider(

--- a/features/providers/pihole/provider.go
+++ b/features/providers/pihole/provider.go
@@ -11,7 +11,6 @@ import (
 	"blacked/internal/config"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -48,8 +47,7 @@ func NewPiholeProvider(cfg *config.Config, collyClient *colly.Collector) base.Pr
 		category = "adlist"
 	}
 
-	processID := uuid.New().String()
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
 		raw, err := io.ReadAll(data)
 		if err != nil {
 			return fmt.Errorf("read pihole data: %w", err)

--- a/features/providers/rtbh/provider.go
+++ b/features/providers/rtbh/provider.go
@@ -56,8 +56,8 @@ func NewRTBHTurkeyProvider(cfg *config.Config, collyClient *colly.Collector) bas
 
 	client := base.BuildCollyClientForProvider(collyClient, opts)
 
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
-		return base.ParseLinesParallel(data, collector, providerName, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
+		return base.ParseLinesParallel(data, collector, providerName, processID, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
 			line = strings.TrimSpace(line)
 			if line == "" || strings.HasPrefix(line, "#") {
 				return nil, nil

--- a/features/providers/threatfox/provider.go
+++ b/features/providers/threatfox/provider.go
@@ -19,7 +19,6 @@ import (
 	"blacked/internal/db"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -89,8 +88,7 @@ func NewThreatFoxProvider(cfg *config.Config, collyClient *colly.Collector) base
 		client.MaxBodySize = 100 * 1024 * 1024 // 100 MB
 	}
 
-	processID := uuid.New().String()
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
 		raw, err := io.ReadAll(data)
 		if err != nil {
 			return fmt.Errorf("read threatfox data: %w", err)

--- a/features/providers/torexitnodes/provider.go
+++ b/features/providers/torexitnodes/provider.go
@@ -12,7 +12,6 @@ import (
 	"blacked/internal/config"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -49,8 +48,7 @@ func NewTorExitNodesProvider(cfg *config.Config, collyClient *colly.Collector) b
 		category = "anonymizer"
 	}
 
-	processID := uuid.New().String()
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
 		raw, err := io.ReadAll(data)
 		if err != nil {
 			return fmt.Errorf("read tor exit nodes: %w", err)

--- a/features/providers/urlhaus/urlhaus_abuse.go
+++ b/features/providers/urlhaus/urlhaus_abuse.go
@@ -60,8 +60,8 @@ func NewURLHausProvider(cfg *config.Config, collyClient *colly.Collector) base.P
 		resilienceCfg.Timeout = resCfg.Timeout
 	}
 
-	parseFunc := func(data io.Reader, collector entry_collector.Collector) error {
-		return base.ParseLinesParallel(data, collector, providerName, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
+	parseFunc := func(data io.Reader, collector entry_collector.Collector, processID string) error {
+		return base.ParseLinesParallel(data, collector, providerName, processID, workers, batchSize, func(line, processID string) (*entries.Entry, error) {
 			line = strings.TrimSpace(line)
 			if line == "" || strings.HasPrefix(line, "#") {
 				return nil, nil


### PR DESCRIPTION
## Problem

After PR #50 (processID cache poisoning fix), discovered a **second bug**: ParseLinesParallel was generating its own processID instead of using the one from provider.

**Root cause:**
- Provider starts run with processID=A
- ParseLinesParallel creates its OWN processID=B via uuid.New()
- Entries written with processID=B
- RemoveOlderInsertions called with processID=A
- WHERE process_id != A matches ALL entries → mass deletion

**Evidence from production:**
- 939K entries in DB, ALL deleted (deleted_at set)
- Last run showed processID mismatch between logs and DB

## Solution

1. Added `processID` parameter to ParseLinesParallel
2. Removed local uuid.New() call in parallel_parser.go
3. Updated ALL 15 callers to pass processID from provider level

**Files changed:**
- features/providers/base/parallel_parser.go (signature, removed uuid import)
- features/providers/base/base_provider.go
- features/providers/oisd/oisd_big.go, oisd_nsfw.go
- features/providers/urlhaus/urlhaus_abuse.go
- features/providers/greensnow/provider.go
- features/providers/rtbh/provider.go
- features/providers/openphish/openphish_feed.go
- features/providers/phishtank/online_valid.go
- features/providers/blocklistde/provider.go
- features/providers/cinsarmy/provider.go
- features/providers/emergingthreats/provider.go
- features/providers/torexitnodes/provider.go
- features/providers/pihole/provider.go
- features/providers/threatfox/provider.go
- features/providers/alienvault/provider.go

## Flow after fix

1. Provider generates processID=A at start
2. ParseLinesParallel receives A, writes entries with processID=A
3. RemoveOlderInsertions called with processID=A
4. Correct behavior: only old entries from PREVIOUS runs deleted

## Testing

Before merge:
- Fresh DB, fresh bloom filter
- Run providers
- Verify entries persist (deleted_at IS NULL)
- Verify processID in DB matches processID in logs