### PR TITLE
fix: add missing IP column to Scan calls for entries table

### DIFF
--- a/features/entries/repository/sqlite_blacklist_repository.go
+++ b/features/entries/repository/sqlite_blacklist_repository.go
@@ -159,9 +159,9 @@ func (r *SQLiteRepository) GetAllEntries(ctx context.Context) ([]entries.Entry, 
 		var subDomainsStr string
 		var deletedAt sql.NullInt64 // Use sql.NullInt64 for nullable DATETIME in DB
 		err := rows.Scan(
-			&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &subDomainsStr,
+			&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &entry.IP, &subDomainsStr,
 			&entry.Path, &entry.RawQuery, &entry.SourceURL, &entry.Source, &entry.Category,
-			&entry.Confidence, &entry.CreatedAt, &entry.UpdatedAt, &deletedAt, 
+			&entry.Confidence, &entry.CreatedAt, &entry.UpdatedAt, &deletedAt,
 		)
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to scan row from SQLite")
@@ -193,7 +193,7 @@ func (r *SQLiteRepository) GetEntryByID(ctx context.Context, id string) (*entrie
 	var deletedAt sql.NullInt64 
 
 	err := row.Scan(
-		&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &subDomainsStr,
+		&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &entry.IP, &subDomainsStr,
 		&entry.Path, &entry.RawQuery, &entry.SourceURL, &entry.Source, &entry.Category,
 		&entry.Confidence, &entry.CreatedAt, &entry.UpdatedAt, &deletedAt,
 	)
@@ -257,7 +257,7 @@ func (r *SQLiteRepository) GetEntriesByIDs(ctx context.Context, ids []string) ([
 		var deletedAt sql.NullInt64 
 
 		err := rows.Scan(
-			&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &subDomainsStr,
+			&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &entry.IP, &subDomainsStr,
 			&entry.Path, &entry.RawQuery, &entry.SourceURL, &entry.Source, &entry.Category,
 			&entry.Confidence, &entry.CreatedAt, &entry.UpdatedAt, &deletedAt,
 		)
@@ -304,9 +304,9 @@ func (r *SQLiteRepository) GetEntriesBySource(ctx context.Context, source string
 		var subDomainsStr string
 		var deletedAt sql.NullInt64 
 		err := rows.Scan(
-			&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &subDomainsStr,
+			&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &entry.IP, &subDomainsStr,
 			&entry.Path, &entry.RawQuery, &entry.SourceURL, &entry.Source, &entry.Category,
-			&entry.Confidence, &entry.CreatedAt, &entry.UpdatedAt, &deletedAt, 
+			&entry.Confidence, &entry.CreatedAt, &entry.UpdatedAt, &deletedAt,
 		)
 		if err != nil {
 			log.Err(err).
@@ -354,9 +354,9 @@ func (r *SQLiteRepository) GetEntriesByCategory(ctx context.Context, category st
 		var subDomainsStr string
 		var deletedAt sql.NullInt64 
 		err := rows.Scan(
-			&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &subDomainsStr,
+			&entry.ID, &entry.ProcessID, &entry.Scheme, &entry.Domain, &entry.Host, &entry.IP, &subDomainsStr,
 			&entry.Path, &entry.RawQuery, &entry.SourceURL, &entry.Source, &entry.Category,
-			&entry.Confidence, &entry.CreatedAt, &entry.UpdatedAt, &deletedAt, 
+			&entry.Confidence, &entry.CreatedAt, &entry.UpdatedAt, &deletedAt,
 		)
 		if err != nil {
 			log.Err(err).


### PR DESCRIPTION
## Problem
After provider processing completes and stale entry removal succeeds, bloom filter rebuild fails with:
```
sql: expected 16 destination arguments in Scan, not 15
```

## Root Cause
The `entries` table schema has 16 columns (including `ip` between `host` and `sub_domains`), but all `Scan()` calls in `sqlite_blacklist_repository.go` were only scanning 15 fields - missing the `ip` column.

## Fix
Added `&entry.IP` to all 5 Scan calls after `&entry.Host` to match the database schema:
- `GetAllEntries` (line 162)
- `GetEntryByID` (line 196)
- `GetEntriesByProcessID` (line 260)
- `GetEntriesBySource` (line 307)
- `GetEntriesByCategory` (line 357)

## Testing
- Build succeeds: `go build -o blacked .`
- This fixes the bloom filter rebuild failure