### PR TITLE
feat: hard-delete purge for soft-deleted entries

### DIFF
--- a/features/entries/repository/blacklist_repository.go
+++ b/features/entries/repository/blacklist_repository.go
@@ -4,6 +4,7 @@ import (
 	"blacked/features/entries"
 	"blacked/features/entries/enums"
 	"context"
+	"time"
 )
 
 // BlacklistRepository interface defines the data access methods for blacklist entries.
@@ -25,4 +26,5 @@ type BlacklistRepository interface {
 	QueryLink(ctx context.Context, link string) ([]entries.Hit, error)
 	QueryLinkByType(ctx context.Context, link string, queryType *enums.QueryType) ([]entries.Hit, error)
 	QueryExactURLMatch(ctx context.Context, normalizedLink string) []entries.Hit
+	HardDeleteOlderThan(ctx context.Context, cutoff time.Time) error
 }

--- a/features/entries/repository/sqlite_blacklist_repository.go
+++ b/features/entries/repository/sqlite_blacklist_repository.go
@@ -44,11 +44,11 @@ func NewSQLiteRepository(db *sql.DB) *SQLiteRepository {
 func (r *SQLiteRepository) StreamEntriesCount(ctx context.Context) (int, error) {
 	query := `
 	SELECT
-        COUNT(DISTINCT source_url)
-    FROM
-        entries
-    WHERE
-        deleted_at IS NULL;
+		COUNT(DISTINCT source_url)
+	FROM
+		entries
+	WHERE
+		deleted_at IS NULL;
 	`
 
 	row := r.db.QueryRowContext(ctx, query)
@@ -63,11 +63,11 @@ func (r *SQLiteRepository) StreamEntriesCount(ctx context.Context) (int, error) 
 func (r *SQLiteRepository) StreamEntriesCountBySource(ctx context.Context, source string) (int, error) {
 	query := `
 	SELECT
-        COUNT(DISTINCT source_url)
-    FROM
-        entries
-    WHERE
-        deleted_at IS NULL AND source = ?;
+		COUNT(DISTINCT source_url)
+	FROM
+		entries
+	WHERE
+		deleted_at IS NULL AND source = ?;
 	`
 
 	row := r.db.QueryRowContext(ctx, query, source)
@@ -96,15 +96,15 @@ func (r *SQLiteRepository) StreamEntries(ctx context.Context, out chan<- entries
 
 	query := `
 	SELECT
-        source_url,
-        GROUP_CONCAT(id, ',') as ids
-    FROM
-    	entries
-    WHERE
-        deleted_at IS NULL
-    GROUP BY
-    	source_url;
-    `
+		source_url,
+		GROUP_CONCAT(id, ',') as ids
+	FROM
+		entries
+	WHERE
+		deleted_at IS NULL
+	GROUP BY
+		source_url;
+	`
 
 	rows, err := r.db.QueryContext(ctx, query)
 	if err != nil {
@@ -468,22 +468,22 @@ func (r *SQLiteRepository) BatchSaveEntries(ctx context.Context, entries []*entr
 	defer tx.Rollback()
 
 	stmt, err := tx.PrepareContext(ctx, `
-        INSERT INTO entries (
-            id, process_id, scheme, domain, host, sub_domains, path, raw_query, source_url, source, category, confidence, created_at, updated_at, deleted_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
-        ON CONFLICT (source_url, source, host) DO UPDATE SET
-            process_id = EXCLUDED.process_id,
-            scheme = EXCLUDED.scheme,
-            domain = EXCLUDED.domain,
-            host = EXCLUDED.host,
-            sub_domains = EXCLUDED.sub_domains,
-            path = EXCLUDED.path,
-            raw_query = EXCLUDED.raw_query,
-            category = EXCLUDED.category,
-            confidence = EXCLUDED.confidence,
-            updated_at = EXCLUDED.updated_at,
-            deleted_at = NULL
-    `)
+		INSERT INTO entries (
+			id, process_id, scheme, domain, host, sub_domains, path, raw_query, source_url, source, category, confidence, created_at, updated_at, deleted_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+		ON CONFLICT (source_url, source, host) DO UPDATE SET
+			process_id = EXCLUDED.process_id,
+			scheme = EXCLUDED.scheme,
+			domain = EXCLUDED.domain,
+			host = EXCLUDED.host,
+			sub_domains = EXCLUDED.sub_domains,
+			path = EXCLUDED.path,
+			raw_query = EXCLUDED.raw_query,
+			category = EXCLUDED.category,
+			confidence = EXCLUDED.confidence,
+			updated_at = EXCLUDED.updated_at,
+			deleted_at = NULL
+	`)
 	if err != nil {
 		log.Err(err).Msg("Failed to prepare batch insert statement")
 		return ErrTxPrepare
@@ -504,8 +504,8 @@ func (r *SQLiteRepository) BatchSaveEntries(ctx context.Context, entries []*entr
 
 		_, err := stmt.ExecContext(ctx,
 			entry.ID, entry.ProcessID, entry.Scheme, entry.Domain, entry.Host, subDomainsStr,
-		entry.Path, entry.RawQuery, entry.SourceURL, entry.Source, entry.Category, entry.Confidence,
-		entry.CreatedAt, entry.UpdatedAt,
+			entry.Path, entry.RawQuery, entry.SourceURL, entry.Source, entry.Category, entry.Confidence,
+			entry.CreatedAt, entry.UpdatedAt,
 		)
 		if err != nil {
 			log.Error().Err(err).Str("entry_id", entry.ID).Str("source_url", entry.SourceURL).Msg("Error executing batch statement for entry")
@@ -920,4 +920,37 @@ func (r *SQLiteRepository) queryPathMatch(ctx context.Context, path string) []en
 	log.Debug().Dur("duration", time.Since(startTime)).Str("match_type", "PATH").Msg("Path match query completed")
 
 	return hits
+}
+
+// HardDeleteOlderThan permanently deletes entries that were soft-deleted before the cutoff time
+func (r *SQLiteRepository) HardDeleteOlderThan(ctx context.Context, cutoff time.Time) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		log.Err(err).Msg("Failed to begin transaction for HardDeleteOlderThan")
+		return ErrTx
+	}
+	defer tx.Rollback()
+
+	cutoffUnix := cutoff.UnixNano()
+	result, err := tx.ExecContext(ctx, `
+		DELETE FROM entries 
+		WHERE deleted_at < ? AND deleted_at IS NOT NULL
+	`, cutoffUnix)
+
+	if err != nil {
+		log.Error().Err(err).Time("cutoff", cutoff).Msg("Failed to hard delete entries older than cutoff")
+		return ErrDelete
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to get rows affected count during HardDeleteOlderThan")
+	} else {
+		log.Info().
+			Int64("rows_deleted", rowsAffected).
+			Time("cutoff", cutoff).
+			Msg("Hard deleted entries older than cutoff")
+	}
+
+	return tx.Commit()
 }

--- a/features/entry_collector/pond_collector.go
+++ b/features/entry_collector/pond_collector.go
@@ -677,6 +677,18 @@ func (c *PondCollector) RemoveStaleEntriesAndSyncBloom(ctx context.Context, prov
 		Str("process_id", processID).
 		Msg("Bloom filter rebuild completed")
 
+	// Hard delete entries older than the retention period
+	retentionDays := config.GetConfig().Collector.RetentionDays
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	if err := c.repo.HardDeleteOlderThan(ctx, cutoff); err != nil {
+		log.Error().Err(err).
+			Str("provider", providerName).
+			Str("process_id", processID).
+			Int("retention_days", retentionDays).
+			Msg("Failed to hard delete entries older than retention period")
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type CollectorConfig struct {
 	CronSchedule   string `koanf:"cron_schedule" default:"0 0 0 * * *"`
 	StoreResponses bool   `koanf:"store_responses" default:"true"`
 	StorePath      string `koanf:"store_path" default:"./responses"`
+	RetentionDays  int    `koanf:"retention_days" default:"30"`
 }
 
 type ProviderOptions struct {


### PR DESCRIPTION
## Summary

Add hard-delete purge mechanism to prevent unbounded database growth from soft-deleted entries.

## Changes

### 1. BlacklistRepository Interface
- Added  method

### 2. SQLite Implementation
- Transactional DELETE with parameterized query
- Only targets soft-deleted entries (deleted_at IS NOT NULL)

### 3. PondCollector Integration
- Calls HardDeleteOlderThan after RemoveStaleEntriesAndSyncBloom
- Configurable retention period (30 days default)

### 4. Config
- Added RetentionDays to CollectorConfig

## Test
go build ./... && go test ./...

## Acceptance Criteria
- [x] HardDeleteOlderThan method in interface
- [x] SQLite transactional implementation  
- [x] Integration into PondCollector workflow
- [x] Configurable retention period
- [x] Build + test pass