### PR TITLE
fix: fresh colly collector instead of Clone()

### DIFF
--- a/features/providers/base/base_provider.go
+++ b/features/providers/base/base_provider.go
@@ -213,7 +213,7 @@ func (b *BaseProvider) FetchWithContext(ctx context.Context) (io.Reader, error) 
 		
 		var responseBody []byte
 		var fetchErr error
-		c := b.CollyClient.Clone()
+		c := colly.NewCollector()
 		
 		// Apply timeout from resilience config
 		c.SetRequestTimeout(resCfg.Timeout)


### PR DESCRIPTION
Replace Clone() with colly.NewCollector() to prevent inheriting visited URLs and browser UA. Tests pass.