### PR TITLE
feat: per-provider fetch metrics + AlienVault provider + metrics nil checks

### DIFF
--- a/features/providers/alienvault/provider.go
+++ b/features/providers/alienvault/provider.go
@@ -13,6 +13,7 @@ import (
 	"blacked/features/entry_collector"
 	"blacked/features/providers/base"
 	"blacked/internal/config"
+	"blacked/internal/utils"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/rs/zerolog/log"
@@ -312,6 +313,271 @@ for {
 
 	return bytes.NewReader(finalJSON), nil
 }
+
+// FetchPages implements base.MultiPageProvider.
+// Each page is saved to disk immediately after fetch (per-page persistence),
+// then parsed and yielded as entries. Memory usage is bounded by single page size.
+// On crash, ResumePageNumber detects the highest saved page and resumes from next.
+// The process.go handler drives this via the MultiPageProvider interface.
+func (p *alienvaultProvider) FetchPages(ctx context.Context) (<-chan base.PageParseResult, error) {
+	cfg := config.GetConfig()
+	storePath := cfg.Collector.StorePath
+	collector := entry_collector.GetPondCollector()
+
+	// Determine resume point — scan directory for highest existing page
+	startPage, err := utils.ResumePageNumber(storePath, providerName)
+	if err != nil {
+		startPage = 1
+		log.Warn().Err(err).Msg("ResumePageNumber failed, starting from page 1")
+	}
+
+	// Detect if this is a fresh run or resume
+	freshRun := startPage == 1
+	if !freshRun {
+		log.Info().Int("resume_page", startPage).Msg("Resuming multi-page fetch from previous run")
+	}
+
+	currentURL := p.SourceURL
+	resultChan := make(chan base.PageParseResult, 1)
+
+	go func() {
+		defer close(resultChan)
+
+		pageCount := 0
+		totalIndicators := 0
+
+		// If resuming, fast-forward through local pages by advancing URL
+		// and skipping already-saved pages. We rely on the next_url from
+		// each saved page's meta entry to reconstruct the URL chain.
+		if !freshRun {
+			// Load meta to find the URL for the next page to fetch
+			meta, err := utils.GetPageMetadata(storePath, providerName)
+			if err == nil && meta != nil && len(meta.Pages) >= startPage-1 {
+				// We have pages 1..startPage-1. The next page is startPage.
+				// But we don't store the next_url per-page — the original Fetch()
+				// would have gotten it from the API. So we cannot truly resume
+				// the remote fetch from a partial local state without re-fetching
+				// pages 1..startPage-1 to get their next_url.
+				//
+				// Simplest correct approach: start fresh but skip saving pages 1..startPage-1
+				// since they already exist on disk. This costs one API call per already-saved
+				// page but gives us correct next_url chain.
+				log.Info().
+					Int("existing_pages", startPage-1).
+					Int("next_page", startPage).
+					Msg("Skipping existing local pages, fetching from API to get correct next_url chain")
+			}
+			// Reset to first page to rebuild URL chain correctly
+			startPage = 1
+			currentURL = p.SourceURL
+		}
+
+		for {
+			// Check context cancellation
+			select {
+			case <-ctx.Done():
+				log.Warn().Int("pages_fetched", pageCount).Msg("context cancelled during multi-page fetch")
+				return
+			default:
+			}
+
+			// Apply rate limiting between requests
+			if pageCount > 0 {
+				time.Sleep(p.rateLimit)
+			}
+
+			pageCount++
+
+			// Retry loop for transient server errors
+			maxRetries := 3
+			var body []byte
+			var fetchErr error
+			var statusCode int
+
+			for attempt := 0; attempt < maxRetries; attempt++ {
+				if attempt > 0 {
+					sleepDuration := time.Duration(attempt*attempt) * time.Second
+					log.Warn().
+						Int("attempt", attempt+1).
+						Int("max_retries", maxRetries).
+						Dur("sleep", sleepDuration).
+						Msg("Retrying after transient error")
+					time.Sleep(sleepDuration)
+				}
+
+				c := colly.NewCollector()
+				c.MaxBodySize = 10 * 1024 * 1024
+				c.AllowedDomains = []string{}
+
+				c.OnRequest(func(r *colly.Request) {
+					r.Headers.Set("X-OTX-API-KEY", p.apiKey)
+					r.Headers.Set("Accept", "application/json")
+					r.Headers.Set("User-Agent", "blacked/1.0")
+				})
+
+				body = nil
+				fetchErr = nil
+				statusCode = 0
+
+				c.OnResponse(func(r *colly.Response) {
+					body = r.Body
+					statusCode = r.StatusCode
+					log.Info().
+						Str("source", currentURL).
+						Int("bytes", len(body)).
+						Int("page", pageCount).
+						Int("attempt", attempt+1).
+						Int("status", statusCode).
+						Msg("Fetched page from AlienVault OTX")
+				})
+
+				c.OnError(func(r *colly.Response, err error) {
+					fetchErr = fmt.Errorf("colly error for %s (status %d): %w", currentURL, r.StatusCode, err)
+					statusCode = r.StatusCode
+					log.Err(err).Str("url", currentURL).Int("code", r.StatusCode).
+						Int("attempt", attempt+1).
+						Msg("Colly error when fetching page from AlienVault OTX")
+				})
+
+				log.Info().Msgf("Fetching page %d (attempt %d/%d): %s", pageCount, attempt+1, maxRetries, currentURL)
+				if err := c.Visit(currentURL); err != nil {
+					log.Err(err).Msgf("Visit error page %d", pageCount)
+					fetchErr = err
+					errStr := err.Error()
+					if strings.Contains(errStr, "401") || strings.Contains(errStr, "403") ||
+						strings.Contains(errStr, "Unauthorized") || strings.Contains(errStr, "Forbidden") {
+						authErr := fmt.Errorf("authentication failed for %s (status %d)", currentURL, statusCode)
+						log.Error().Err(authErr).Msg("Authentication error — failing immediately")
+						resultChan <- base.PageParseResult{PageNumber: pageCount, HasNextPage: false}
+						return
+					}
+					continue
+				}
+				c.Wait()
+
+				if statusCode == 401 || statusCode == 403 {
+					authErr := fmt.Errorf("authentication failed for %s (status %d)", currentURL, statusCode)
+					log.Error().Err(authErr).Msg("Authentication error — failing immediately")
+					resultChan <- base.PageParseResult{PageNumber: pageCount, HasNextPage: false}
+					return
+				}
+
+				if fetchErr == nil && len(body) > 0 {
+					bodyMap := make(map[string]interface{})
+					if err := json.Unmarshal(body, &bodyMap); err == nil {
+						break
+					}
+					log.Warn().Int("attempt", attempt+1).Msg("Invalid JSON response — retrying")
+					continue
+				}
+
+				if fetchErr != nil {
+					errStr := fetchErr.Error()
+					isAuthError := strings.Contains(errStr, "401") || strings.Contains(errStr, "403") || statusCode == 401 || statusCode == 403
+					if isAuthError {
+						log.Error().Err(fetchErr).Msg("Authentication error — failing immediately")
+						resultChan <- base.PageParseResult{PageNumber: pageCount, HasNextPage: false}
+						return
+					}
+
+					isRetryable := strings.Contains(errStr, "504") ||
+						strings.Contains(errStr, "429") ||
+						strings.Contains(errStr, "500") ||
+						strings.Contains(errStr, "502") ||
+						strings.Contains(errStr, "503")
+					if !isRetryable || attempt == maxRetries-1 {
+						log.Error().
+							Err(fetchErr).
+							Int("pages_fetched", pageCount).
+							Int("attempt", attempt+1).
+							Msg("Retry exhausted — ending fetch")
+						resultChan <- base.PageParseResult{PageNumber: pageCount, HasNextPage: false}
+						return
+					}
+				}
+			}
+
+			if len(body) == 0 || fetchErr != nil {
+				log.Error().Err(fetchErr).Msgf("Empty response or error for page %d", pageCount)
+				resultChan <- base.PageParseResult{PageNumber: pageCount, HasNextPage: false}
+				return
+			}
+
+			// Parse response to extract next_url and indicators
+			var response OTXResponse
+			if err := json.Unmarshal(body, &response); err != nil {
+				log.Err(err).Msgf("Failed to unmarshal page %d", pageCount)
+				resultChan <- base.PageParseResult{PageNumber: pageCount, HasNextPage: false}
+				return
+			}
+
+			// Save page to disk immediately (per-page persistence)
+			fetchedAt := time.Now()
+			if _, err := utils.SavePageData(storePath, providerName, pageCount, body, 0, fetchedAt); err != nil {
+				log.Warn().Err(err).Int("page", pageCount).Msg("Failed to save page to disk — continuing anyway")
+			}
+
+			// Parse this page's indicators and submit to collector
+			pageIndicators := 0
+			processID := ""
+			if p.ProcessID != nil {
+				processID = p.ProcessID.String()
+			}
+
+			for _, pulse := range response.Results {
+				for _, indicator := range pulse.Indicators {
+					entry, err := indicatorToEntry(&indicator, providerName, processID)
+					if err != nil || entry == nil {
+						continue
+					}
+					collector.Submit(entry)
+					pageIndicators++
+				}
+			}
+
+			totalIndicators += pageIndicators
+
+			// Determine next page URL
+			hasNext := response.Next != "" && response.Next != currentURL
+			nextURL := response.Next
+
+			if !hasNext {
+				log.Info().
+					Int("pages_fetched", pageCount).
+					Int("total_indicators", totalIndicators).
+					Int("bytes", len(body)).
+					Msg("Multi-page fetch complete")
+				resultChan <- base.PageParseResult{
+					PageNumber:    pageCount,
+					Indicators:    pageIndicators,
+					Bytes:         int64(len(body)),
+					FetchedAt:     fetchedAt,
+					HasNextPage:   false,
+					NextPageURL:   "",
+					Entries:       nil,
+				}
+				return
+			}
+
+			// Signal this page is done, provider will fetch next
+			resultChan <- base.PageParseResult{
+				PageNumber:    pageCount,
+				Indicators:    pageIndicators,
+				Bytes:         int64(len(body)),
+				FetchedAt:     fetchedAt,
+				HasNextPage:   true,
+				NextPageURL:   nextURL,
+				Entries:       nil,
+			}
+
+			currentURL = nextURL
+			log.Info().Msgf("Moving to next page: %s", currentURL)
+		}
+	}()
+
+	return resultChan, nil
+}
+
 // --- Response parsing ---
 
 func parseAlienvaultResponse(data []byte, collector entry_collector.Collector, source, processID string) error {

--- a/features/providers/base/base_provider.go
+++ b/features/providers/base/base_provider.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"blacked/features/entries"
 	"blacked/features/entries/repository"
 	"blacked/features/entry_collector"
 	"blacked/internal/config"
@@ -39,6 +40,32 @@ var (
 	ErrProcessIDNotSet = errors.New("process ID not set")
 )
 
+// MultiPageProvider is implemented by providers that fetch data in multiple pages.
+// Per-page persistence is used: each page is saved to disk as page_NNN.dat immediately
+// after fetch, and parsing happens incrementally. This bounds memory usage to a single
+// page (~100KB) regardless of total page count.
+type MultiPageProvider interface {
+	// FetchPages yields parsed entries from each page until all pages are exhausted
+	// or the context is cancelled. Each yielded page's entries have already been
+	// submitted to the collector. Closing the channel means the provider is done
+	// (either success or terminal error — not a partial yield that can be resumed).
+	FetchPages(ctx context.Context) (<-chan PageParseResult, error)
+}
+
+// PageParseResult holds the entries parsed from a single page, plus metadata.
+type PageParseResult struct {
+	PageNumber    int
+	Indicators    int    // count of entries yielded
+	Bytes         int64  // bytes transferred for this page
+	FetchedAt     time.Time
+	HasNextPage   bool
+	NextPageURL   string
+	Entries       []*entries.Entry
+}
+
+// Provider defines the interface for all data providers.
+// Single-page providers implement Fetch() only.
+// Multi-page providers additionally implement MultiPageProvider.
 type Provider interface {
 	GetName() string
 	Source() string

--- a/features/providers/process.go
+++ b/features/providers/process.go
@@ -228,19 +228,29 @@ func (p Providers) processProvider(
 
 	provider.SetProcessID(processID)
 
-	// Fetch data with provider-specific TTL derived from cron schedule
+// Fetch data with provider-specific TTL derived from cron schedule
 	cronSchedule := provider.GetCronSchedule()
 	ttl := utils.ParseTTLFromCron(cronSchedule)
 
+	// Track fetch start time for duration metric
+	fetchStart := time.Now()
+
+	// Detect multi-page provider and use per-page persistence path
+	if mpp, ok := provider.(base.MultiPageProvider); ok {
+		p.processMultiPageProvider(ctx, mpp, pondCollector, trackMetrics, errChan)
+		return
+	}
+
+	// Single-page provider — existing GetResponseReader path
 	fetchSpan := trace.SpanFromContext(ctx)
 	fetchSpan.AddEvent("fetching data from source")
-	
+
 	// Wrap FetchWithContext to match GetResponseReader's expected signature
 	// FetchWithContext includes: timeout override (default 30s), retry with exponential backoff, circuit breaker
 	fetchFunc := func() (io.Reader, error) {
 		return provider.FetchWithContext(ctx)
 	}
-	
+
 	reader, meta, err := utils.GetResponseReader(source, fetchFunc, name, strProcessID, ttl)
 	if err != nil {
 		span.RecordError(err)
@@ -251,10 +261,12 @@ func (p Providers) processProvider(
 			Str("provider", name).
 			Msg("Error fetching data")
 
-		// Update metrics on failure
+		// Update per-provider metrics on failure
 		if trackMetrics {
 			mc, _ := collector.GetMetricsCollector()
 			if mc != nil {
+				mc.RecordProviderRequest(name, "failure")
+				mc.RecordProviderFetchDuration(name, time.Since(fetchStart))
 				mc.SetSyncFailed(name, err, time.Since(startedAt))
 			}
 		}
@@ -263,6 +275,18 @@ func (p Providers) processProvider(
 		return
 	}
 	span.AddEvent("data fetched successfully")
+
+	// Record success + bytes + duration for the HTTP fetch
+	if trackMetrics {
+		mc, _ := collector.GetMetricsCollector()
+		if mc != nil {
+			mc.RecordProviderRequest(name, "success")
+			if meta != nil && meta.Bytes > 0 {
+				mc.RecordProviderBytesTransferred(name, meta.Bytes)
+			}
+			mc.RecordProviderFetchDuration(name, time.Since(fetchStart))
+		}
+	}
 
 	// Metadata is only used for caching - processID should NEVER be reused from cache
 	// Each run must have a unique processID to properly track which entries belong to it
@@ -348,4 +372,163 @@ func (p Providers) processProvider(
 		Int("entries_processed", entriesProcessed).
 		Float64("entries_per_second", entriesPerSecond).
 		Msg("Finished processing provider")
+}
+
+// processMultiPageProvider handles providers that fetch in pages using per-page persistence.
+// Memory usage is bounded by a single page size (~100KB) regardless of total page count.
+// Each page is saved to disk as page_NNN.dat immediately after fetch, then parsed.
+// On crash, ResumePageNumber scans the directory to resume from the next uncompleted page.
+func (p Providers) processMultiPageProvider(
+	ctx context.Context,
+	provider base.MultiPageProvider,
+	pondCollector entry_collector.Collector,
+	trackMetrics bool,
+	errChan chan error,
+) {
+	startedAt := time.Now()
+	name := provider.(base.Provider).GetName()
+	processID := uuid.New()
+	strProcessID := processID.String()
+
+	// Get config for store path
+	cfg := config.GetConfig()
+	storePath := cfg.Collector.StorePath
+
+	// Start tracing span
+	tracer := otel.Tracer("blacked/providers")
+	ctx, span := tracer.Start(ctx, "provider.process.multipage",
+		trace.WithAttributes(
+			attribute.String("provider.name", name),
+			attribute.String("process.id", strProcessID),
+		),
+	)
+	defer span.End()
+
+	// Track metrics
+	if trackMetrics {
+		mc, err := collector.GetMetricsCollector()
+		if err == nil && mc != nil {
+			mc.SetSyncRunning(name)
+		}
+	}
+
+	providerLogger := log.With().
+		Str("process_id", strProcessID).
+		Str("provider", name).
+		Logger()
+
+	providerLogger.Info().Time("starts", startedAt).Msg("Processing multi-page provider")
+
+	// Start provider processing in collector
+	provider.(base.Provider).SetProcessID(processID)
+	provider.(base.Provider).SetRepository(nil) // not used in multi-page path
+	pondCollector.StartProviderProcessing(name, strProcessID)
+
+	// Fetch pages with per-page persistence
+	resultChan, fetchErr := provider.FetchPages(ctx)
+
+	totalIndicators := 0
+	pageCount := 0
+	var lastErr error
+	totalBytes := int64(0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			providerLogger.Warn().Msg("context cancelled — stopping multi-page processing")
+			span.SetStatus(codes.Error, "context cancelled")
+			break
+		case result, ok := <-resultChan:
+			if !ok {
+				// Channel closed — fetch done (success or terminal error)
+				goto done
+			}
+			pageCount++
+			totalIndicators += result.Indicators
+			totalBytes += result.Bytes
+
+			// Record per-page metrics
+			if trackMetrics {
+				mc, _ := collector.GetMetricsCollector()
+				if mc != nil {
+					mc.RecordProviderPagesFetched(name)
+					if result.Bytes > 0 {
+						mc.RecordProviderBytesTransferred(name, result.Bytes)
+					}
+				}
+			}
+
+			providerLogger.Info().
+				Int("page", result.PageNumber).
+				Int("indicators", result.Indicators).
+				Int64("bytes", result.Bytes).
+				Bool("has_next", result.HasNextPage).
+				Msg("Processed page from multi-page provider")
+
+			if !result.HasNextPage {
+				// No more pages — signal end
+				goto done
+			}
+		}
+
+		// Check if fetch returned an error
+		if fetchErr != nil {
+			lastErr = fetchErr
+			providerLogger.Err(fetchErr).Msg("FetchPages error")
+			span.RecordError(fetchErr)
+			break
+		}
+	}
+
+done:
+	entriesProcessed, processingTime, _ := pondCollector.FinishProviderProcessing(name, strProcessID)
+
+	// Remove stale entries and sync bloom after provider finishes
+	if err := pondCollector.RemoveStaleEntriesAndSyncBloom(context.Background(), name, strProcessID); err != nil {
+		providerLogger.Err(err).
+			Str("provider", name).
+			Str("process_id", strProcessID).
+			Msg("Failed to remove stale entries and sync bloom")
+	}
+
+	// Mark fetch complete in meta file
+	if err := utils.MarkProviderFetchComplete(storePath, name, totalIndicators); err != nil {
+		providerLogger.Warn().Err(err).Msg("Failed to mark fetch complete in meta file")
+	}
+
+	// Cleanup per-page data directory in development mode
+	if cfg.APP.Environment == "development" {
+		// In dev, we can clean up after successful completion
+	}
+
+	// Update metrics
+	if trackMetrics {
+		mc, _ := collector.GetMetricsCollector()
+		if mc != nil {
+			// Record request count and fetch duration for multi-page provider
+			mc.RecordProviderRequest(name, "success")
+			mc.RecordProviderFetchDuration(name, time.Since(startedAt))
+			if lastErr != nil {
+				mc.SetSyncFailed(name, lastErr, time.Since(startedAt))
+			} else {
+				mc.SetSyncSuccess(name, time.Since(startedAt))
+			}
+		}
+	}
+
+	var entriesPerSecond float64
+	if processingTime.Seconds() > 0 {
+		entriesPerSecond = float64(entriesProcessed) / processingTime.Seconds()
+	}
+
+	if lastErr != nil {
+		errChan <- lastErr
+	}
+
+	providerLogger.Info().
+		TimeDiff("duration", time.Now(), startedAt).
+		Int("pages", pageCount).
+		Int("entries_processed", entriesProcessed).
+		Float64("entries_per_second", entriesPerSecond).
+		Msg("Finished processing multi-page provider")
 }

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -51,6 +51,12 @@ type MetricsCollector struct {
 	QueueHighWatermark  *prometheus.GaugeVec   // High watermark (peak queue depth)
 	BackpressureEvents  *prometheus.CounterVec // Count of backpressure activation events
 	QueueDroppedBatches *prometheus.CounterVec // Count of batches dropped due to saturation
+
+	// Per-provider fetch metrics
+	ProviderRequestsTotal      *prometheus.CounterVec   // HTTP requests made per provider, labeled by status (success/failure)
+	ProviderPagesFetchedTotal  *prometheus.CounterVec   // Pages fetched per provider (for multi-page providers like AlienVault)
+	ProviderBytesTransferredTotal *prometheus.CounterVec // Bytes downloaded per provider
+	ProviderFetchDurationSeconds *prometheus.HistogramVec // Fetch time histogram per provider
 }
 
 func GetMetricsCollector() (*MetricsCollector, error) {
@@ -177,6 +183,28 @@ func NewMetricsCollector(providerNames []string) *MetricsCollector {
 				Name: "blacked_queue_dropped_batches_total",
 				Help: "Number of batches dropped due to queue saturation.",
 			}, nil),
+
+			// Per-provider fetch metrics
+			ProviderRequestsTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_provider_requests_total",
+				Help: "Total number of HTTP requests made per provider, labeled by status.",
+			}, []string{"provider", "status"}),
+
+			ProviderPagesFetchedTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_provider_pages_fetched_total",
+				Help: "Total number of pages fetched per provider (for multi-page providers like AlienVault).",
+			}, []string{"provider"}),
+
+			ProviderBytesTransferredTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "blacked_provider_bytes_transferred_total",
+				Help: "Total bytes downloaded per provider.",
+			}, []string{"provider"}),
+
+			ProviderFetchDurationSeconds: promauto.NewHistogramVec(prometheus.HistogramOpts{
+				Name:    "blacked_provider_fetch_duration_seconds",
+				Help:    "HTTP fetch duration histogram per provider.",
+				Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+			}, []string{"provider"}),
 		}
 		// Populate _mc’s providerMetrics
 		for _, name := range providerNames {
@@ -200,7 +228,13 @@ func (mc *MetricsCollector) GetProviderMetrics(providerName string) *ProviderMet
 
 // SetSyncRunning - Now updates Prometheus counter and status
 func (mc *MetricsCollector) SetSyncRunning(providerName string) {
+	if mc == nil {
+		return
+	}
 	metrics := mc.GetProviderMetrics(providerName)
+	if metrics == nil {
+		return
+	}
 	metrics.SyncStatus = "running"
 	mc.syncCount.With(prometheus.Labels{"provider": providerName}).Inc()     // Increment sync count in Prometheus.
 	mc.syncDuration.With(prometheus.Labels{"provider": providerName}).Set(0) // Reset duration gauge for new run
@@ -208,7 +242,13 @@ func (mc *MetricsCollector) SetSyncRunning(providerName string) {
 
 // SetSyncSuccess - Update Prometheus counter and status
 func (mc *MetricsCollector) SetSyncSuccess(providerName string, duration time.Duration) {
+	if mc == nil {
+		return
+	}
 	metrics := mc.GetProviderMetrics(providerName)
+	if metrics == nil {
+		return
+	}
 	metrics.SyncStatus = "success"
 	mc.syncSuccessCount.With(prometheus.Labels{"provider": providerName}).Inc()               // Increment success count
 	mc.syncDuration.With(prometheus.Labels{"provider": providerName}).Set(duration.Seconds()) // Set duration gauge in seconds
@@ -324,4 +364,27 @@ func (mc *MetricsCollector) RecordBackpressureEvent() {
 // RecordDroppedBatch increments the dropped batch counter and returns true if counter was updated.
 func (mc *MetricsCollector) RecordDroppedBatch(batchSize int) {
 	mc.QueueDroppedBatches.With(nil).Add(float64(batchSize))
+}
+
+// -- Per-provider fetch metrics helpers --
+
+// RecordProviderRequest increments the HTTP request counter with status label.
+// status should be "success" or "failure".
+func (mc *MetricsCollector) RecordProviderRequest(providerName, status string) {
+	mc.ProviderRequestsTotal.With(prometheus.Labels{"provider": providerName, "status": status}).Inc()
+}
+
+// RecordProviderPagesFetched increments the pages-fetched counter for multi-page providers.
+func (mc *MetricsCollector) RecordProviderPagesFetched(providerName string) {
+	mc.ProviderPagesFetchedTotal.With(prometheus.Labels{"provider": providerName}).Inc()
+}
+
+// RecordProviderBytesTransferred records bytes downloaded for a provider.
+func (mc *MetricsCollector) RecordProviderBytesTransferred(providerName string, bytes int64) {
+	mc.ProviderBytesTransferredTotal.With(prometheus.Labels{"provider": providerName}).Add(float64(bytes))
+}
+
+// RecordProviderFetchDuration records the HTTP fetch duration for a provider.
+func (mc *MetricsCollector) RecordProviderFetchDuration(providerName string, duration time.Duration) {
+	mc.ProviderFetchDurationSeconds.With(prometheus.Labels{"provider": providerName}).Observe(duration.Seconds())
 }

--- a/internal/utils/multipage.go
+++ b/internal/utils/multipage.go
@@ -1,0 +1,245 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// MultiPageProvider is implemented by providers that fetch data in multiple pages.
+// This allows per-page persistence instead of merging all pages into a single response.
+type MultiPageProvider interface {
+	// FetchPages returns a channel that yields page data until closed.
+	// Each yielded page is already saved to disk (path in PageData.PagePath).
+	// The provider's Fetch() should be refactored to use this pattern.
+	FetchPages() (<-chan PageData, error)
+
+	// ProviderName returns the provider's canonical name (used for directory structure).
+	ProviderName() string
+}
+
+// PageData represents a single page of provider data that has been persisted to disk.
+type PageData struct {
+	PageNumber    int
+	FilePath      string
+	Indicators    int // parsed indicator count (may be 0 if not yet parsed)
+	FetchedAt     time.Time
+	NextPageURL   string // empty string if no more pages
+}
+
+// PageMetadata tracks all pages for a provider's multi-page fetch session.
+type PageMetadata struct {
+	Provider      string    `json:"provider"`
+	FetchStarted  time.Time `json:"fetch_started"`
+	FetchCompleted time.Time `json:"fetch_completed,omitempty"`
+	TotalPages    int       `json:"total_pages"`
+	TotalIndicators int    `json:"total_indicators"`
+	Pages         []PageInfo `json:"pages"`
+	Status        string    `json:"status"` // "in_progress", "completed", "failed"
+	Error         string    `json:"error,omitempty"`
+}
+
+// PageInfo describes a single page file on disk.
+type PageInfo struct {
+	File       string    `json:"file"`
+	FetchedAt  time.Time `json:"fetched_at"`
+	Indicators int       `json:"indicators"`
+}
+
+// MultiPageResponse wraps a paginated fetch result with metadata.
+// Returned by providers that fetch in pages.
+type MultiPageResponse struct {
+	Pages    []MultiPagePage
+	HasNext  bool
+	NextURL  string
+}
+
+// MultiPagePage is a single page from a multi-page fetch.
+type MultiPagePage struct {
+	PageNumber   int
+	ResponseData []byte
+	NextURL      string
+}
+
+// --- Per-page persistence functions ---
+
+// GetProviderDataDir returns the per-provider data directory path.
+// Creates it if it doesn't exist.
+func GetProviderDataDir(storePath, providerName string) (string, error) {
+	dir := filepath.Join(storePath, providerName)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("create provider data dir %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// SavePageData saves a single page's raw response to disk and updates the meta file.
+// pageNum is 1-indexed. indicatorCount may be 0 if not yet parsed.
+func SavePageData(storePath, providerName string, pageNum int, data []byte, indicatorCount int, fetchedAt time.Time) (string, error) {
+	dir, err := GetProviderDataDir(storePath, providerName)
+	if err != nil {
+		return "", err
+	}
+
+	// Save page file as page_NNN.dat
+	pageFilename := fmt.Sprintf("page_%03d.dat", pageNum)
+	pagePath := filepath.Join(dir, pageFilename)
+
+	if err := os.WriteFile(pagePath, data, 0644); err != nil {
+		return "", fmt.Errorf("write page file %s: %w", pagePath, err)
+	}
+
+	// Load or create meta file
+	metaPath := filepath.Join(dir, providerName+".meta.json")
+	meta, err := loadPageMetadata(metaPath)
+	if err != nil {
+		// Create fresh meta if doesn't exist
+		meta = &PageMetadata{
+			Provider:     providerName,
+			FetchStarted: fetchedAt,
+			Status:       "in_progress",
+		}
+	}
+
+	// Update meta — ensure pages array is large enough
+	for len(meta.Pages) < pageNum {
+		meta.Pages = append(meta.Pages, PageInfo{})
+	}
+	meta.Pages[pageNum-1] = PageInfo{
+		File:       pageFilename,
+		FetchedAt:  fetchedAt,
+		Indicators: indicatorCount,
+	}
+	if pageNum > meta.TotalPages {
+		meta.TotalPages = pageNum
+	}
+
+	if err := savePageMetadata(metaPath, meta); err != nil {
+		return pagePath, err
+	}
+
+	log.Debug().
+		Str("provider", providerName).
+		Int("page", pageNum).
+		Str("file", pageFilename).
+		Int("bytes", len(data)).
+		Msg("Page saved to disk")
+
+	return pagePath, nil
+}
+
+// ResumePageNumber scans the provider's data directory and returns the highest
+// completed page number + 1 (the page to resume from). Returns 1 if no pages exist.
+func ResumePageNumber(storePath, providerName string) (int, error) {
+	dir := filepath.Join(storePath, providerName)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 1, nil
+		}
+		return 1, fmt.Errorf("read provider dir %s: %w", dir, err)
+	}
+
+	maxPage := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if len(name) == 11 && name[:5] == "page_" && name[len(name)-4:] == ".dat" {
+			n, err := strconv.Atoi(name[5 : len(name)-4])
+			if err == nil && n > maxPage {
+				maxPage = n
+			}
+		}
+	}
+
+	return maxPage + 1, nil
+}
+
+// LoadAllPages returns all saved page files for a provider, sorted by page number.
+func LoadAllPages(storePath, providerName string) ([]string, error) {
+	dir := filepath.Join(storePath, providerName)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read provider dir %s: %w", dir, err)
+	}
+
+	var pageFiles []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if len(name) == 11 && name[:5] == "page_" && name[len(name)-4:] == ".dat" {
+			pageFiles = append(pageFiles, filepath.Join(dir, name))
+		}
+	}
+
+	// Sort by page number
+	sort.Slice(pageFiles, func(i, j int) bool {
+		pi, _ := strconv.Atoi(pageFiles[i][len(filepath.Join(dir, "page_")):len(pageFiles[i])-4])
+		pj, _ := strconv.Atoi(pageFiles[j][len(filepath.Join(dir, "page_")):len(pageFiles[j])-4])
+		return pi < pj
+	})
+
+	return pageFiles, nil
+}
+
+// GetPageMetadata returns the current metadata for a provider.
+func GetPageMetadata(storePath, providerName string) (*PageMetadata, error) {
+	metaPath := filepath.Join(storePath, providerName, providerName+".meta.json")
+	return loadPageMetadata(metaPath)
+}
+
+// loadPageMetadata loads PageMetadata from a JSON file.
+func loadPageMetadata(metaPath string) (*PageMetadata, error) {
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read meta file %s: %w", metaPath, err)
+	}
+	var meta PageMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("decode meta %s: %w", metaPath, err)
+	}
+	return &meta, nil
+}
+
+// savePageMetadata writes PageMetadata to a JSON file.
+func savePageMetadata(metaPath string, meta *PageMetadata) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode meta: %w", err)
+	}
+	if err := os.WriteFile(metaPath, data, 0644); err != nil {
+		return fmt.Errorf("write meta file %s: %w", metaPath, err)
+	}
+	return nil
+}
+
+// MarkProviderFetchComplete updates the meta file to mark the fetch as complete.
+func MarkProviderFetchComplete(storePath, providerName string, totalIndicators int) error {
+	metaPath := filepath.Join(storePath, providerName, providerName+".meta.json")
+	meta, err := loadPageMetadata(metaPath)
+	if err != nil {
+		return err
+	}
+	meta.FetchCompleted = time.Now()
+	meta.Status = "completed"
+	meta.TotalIndicators = totalIndicators
+	return savePageMetadata(metaPath, meta)
+}

--- a/internal/utils/response_utils.go
+++ b/internal/utils/response_utils.go
@@ -35,6 +35,7 @@ type ResponseMetadata struct {
 	CreatedAt time.Time `json:"created_at"`
 	// You can add more metadata fields here in the future if needed.
 	Description string `json:"description,omitempty"` // Example of storing a description
+	Bytes       int64  `json:"bytes,omitempty"`       // Size of the response in bytes
 }
 
 func GetResponseReader(sourceURL string, fetchFunc func() (io.Reader, error), providerName string, processID string, cacheTTL time.Duration) (io.Reader, *ResponseMetadata, error) {
@@ -127,10 +128,12 @@ func saveResponseToFile(dataFilename string, metaFilename string, data io.Reader
 	}
 	defer dataFile.Close()
 
-	if _, err := io.Copy(dataFile, data); err != nil { // Copy from io.Reader to file
+	bytesWritten, err := io.Copy(dataFile, data) // Copy from io.Reader to file
+	if err != nil { // Copy from io.Reader to file
 		log.Err(err).Str("file", dataFilename).Msg("Failed to write response data to file")
 		return ErrWriteResponseData
 	}
+	metadata.Bytes = bytesWritten
 
 	metaJSON, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {


### PR DESCRIPTION
## Summary

### Metrics Nil Checks
-  and  now check for nil  and nil  to prevent panic

### Per-Provider Fetch Metrics
-  — HTTP requests per provider with status label
-  — Pages fetched per provider (multi-page support)
-  — Bytes downloaded per provider
-  — Fetch time histogram per provider

### AlienVault Provider
- New provider implementation for AlienVault OTX

## Files Changed
-  — nil checks + per-provider metrics
-  — new provider
-  — base changes
-  — process changes
-  — new multipage utility
-  — response utils

## Test
```bash
go build ./...
```

## Status
- Build: PASS