### PR TITLE
Fix nil pointer dereference in SavePageData

### DIFF
--- a/internal/utils/multipage.go
+++ b/internal/utils/multipage.go
@@ -71,8 +71,8 @@ func SavePageData(storePath, providerName string, pageNum int, data []byte, indi
 	// Load or create meta file
 	metaPath := filepath.Join(dir, providerName+".meta.json")
 	meta, err := loadPageMetadata(metaPath)
-	if err != nil {
-		// Create fresh meta if doesn't exist
+	if err != nil || meta == nil {
+		// Create fresh meta if doesn't exist or failed to load
 		meta = &PageMetadata{
 			Provider:     providerName,
 			FetchStarted: fetchedAt,


### PR DESCRIPTION
## Summary

Fixes nil pointer dereference at  when  returns  for a missing meta file.

## Root Cause

 returns  when the meta file doesn't exist yet. The existing code only checked for  and proceeded with a nil  pointer, causing a panic when accessing .

## Fix

Changed the nil check from:

to:


This ensures a fresh  is created when the file doesn't exist yet.

## Testing

-  passes
- Branch pushed to 