### PR TITLE
feat: per-provider detailed status tracking to /provider/processes

### DIFF
--- a/features/providers/process.go
+++ b/features/providers/process.go
@@ -199,6 +199,9 @@ func (p Providers) processProvider(
 	startedAt := time.Now()
 	strProcessID := processID.String()
 
+	// Get ProcessManager for per-provider status updates
+	pm := GetProcessManager()
+
 	// Start tracing span
 	tracer := otel.Tracer("blacked/providers")
 	ctx, span := tracer.Start(ctx, "provider.process",
@@ -209,6 +212,9 @@ func (p Providers) processProvider(
 		),
 	)
 	defer span.End()
+
+	// Update provider status to running
+	pm.UpdateProviderStatus(name, "running", "fetching_page", 0, 0, 0, 0, nil, 0)
 
 	// Track metrics if enabled in Prometheus
 	if trackMetrics {
@@ -261,6 +267,10 @@ func (p Providers) processProvider(
 			Str("provider", name).
 			Msg("Error fetching data")
 
+		// Update provider status to error
+		errStr := err.Error()
+		pm.UpdateProviderStatus(name, "error", "failed", 0, 0, 0, 0, &errStr, 0)
+
 		// Update per-provider metrics on failure
 		if trackMetrics {
 			mc, _ := collector.GetMetricsCollector()
@@ -276,13 +286,22 @@ func (p Providers) processProvider(
 	}
 	span.AddEvent("data fetched successfully")
 
+	// Record bytes transferred for fetch
+	var bytesTransferred int64
+	if meta != nil {
+		bytesTransferred = meta.Bytes
+	}
+
+	// Update provider status to parsing phase
+	pm.UpdateProviderStatus(name, "running", "parsing", 0, 0, bytesTransferred, 0, nil, 0)
+
 	// Record success + bytes + duration for the HTTP fetch
 	if trackMetrics {
 		mc, _ := collector.GetMetricsCollector()
 		if mc != nil {
 			mc.RecordProviderRequest(name, "success")
-			if meta != nil && meta.Bytes > 0 {
-				mc.RecordProviderBytesTransferred(name, meta.Bytes)
+			if bytesTransferred > 0 {
+				mc.RecordProviderBytesTransferred(name, bytesTransferred)
 			}
 			mc.RecordProviderFetchDuration(name, time.Since(fetchStart))
 		}
@@ -305,6 +324,9 @@ func (p Providers) processProvider(
 	// Start tracking provider metrics in the pond collector
 	pondCollector.StartProviderProcessing(name, strProcessID)
 
+	// Update provider status to writing_db phase
+	pm.UpdateProviderStatus(name, "running", "writing_db", 0, 0, bytesTransferred, 0, nil, 0)
+
 	// Parse the data - this delegates to the provider's implementation
 	span.AddEvent("parsing provider data")
 	if err := provider.Parse(reader); err != nil {
@@ -315,6 +337,10 @@ func (p Providers) processProvider(
 			Str("source", source).
 			Str("provider", name).
 			Msg("Error parsing data")
+
+		// Update provider status to error
+		errStr := err.Error()
+		pm.UpdateProviderStatus(name, "error", "failed", 0, 0, bytesTransferred, 0, &errStr, 0)
 
 		// Finish tracking in the collector
 		pondCollector.FinishProviderProcessing(name, strProcessID)
@@ -352,6 +378,9 @@ func (p Providers) processProvider(
 	if cfg.APP.Environment == "development" {
 		utils.RemoveStoredResponse(name)
 	}
+
+	// Update provider status to completed
+	pm.UpdateProviderStatus(name, "done", "completed", 0, 0, bytesTransferred, 0, nil, entriesProcessed)
 
 	// Update Prometheus metrics on success
 	if trackMetrics {
@@ -394,6 +423,9 @@ func (p Providers) processMultiPageProvider(
 	cfg := config.GetConfig()
 	storePath := cfg.Collector.StorePath
 
+	// Get ProcessManager for per-provider status updates
+	pm := GetProcessManager()
+
 	// Start tracing span
 	tracer := otel.Tracer("blacked/providers")
 	ctx, span := tracer.Start(ctx, "provider.process.multipage",
@@ -403,6 +435,9 @@ func (p Providers) processMultiPageProvider(
 		),
 	)
 	defer span.End()
+
+	// Update provider status to running
+	pm.UpdateProviderStatus(name, "running", "fetching_page", 0, 0, 0, 0, nil, 0)
 
 	// Track metrics
 	if trackMetrics {
@@ -447,6 +482,9 @@ func (p Providers) processMultiPageProvider(
 			totalIndicators += result.Indicators
 			totalBytes += result.Bytes
 
+			// Update provider status with page progress
+			pm.UpdateProviderStatus(name, "running", "fetching_page", pageCount, 0, totalBytes, 0, nil, totalIndicators)
+
 			// Record per-page metrics
 			if trackMetrics {
 				mc, _ := collector.GetMetricsCollector()
@@ -482,6 +520,14 @@ func (p Providers) processMultiPageProvider(
 
 done:
 	entriesProcessed, processingTime, _ := pondCollector.FinishProviderProcessing(name, strProcessID)
+
+	// Update provider status based on outcome
+	if lastErr != nil {
+		errStr := lastErr.Error()
+		pm.UpdateProviderStatus(name, "error", "failed", pageCount, pageCount, totalBytes, 0, &errStr, entriesProcessed)
+	} else {
+		pm.UpdateProviderStatus(name, "done", "completed", pageCount, pageCount, totalBytes, 0, nil, entriesProcessed)
+	}
 
 	// Remove stale entries and sync bloom after provider finishes
 	if err := pondCollector.RemoveStaleEntriesAndSyncBloom(context.Background(), name, strProcessID); err != nil {

--- a/features/providers/process_manager.go
+++ b/features/providers/process_manager.go
@@ -86,10 +86,23 @@ func (pm *ProcessManager) TryStartProcess(ctx context.Context, source string, pr
 			if !pm.isRunning.Load() {
 				processID := uuid.New().String()
 
+				// Initialize per-provider status tracking
+				providerStatuses := make([]*ProviderStatus, 0, len(providersToProcess))
+				now := time.Now()
+				for _, name := range providersToProcess {
+					providerStatuses = append(providerStatuses, &ProviderStatus{
+						Name:          name,
+						Status:        "pending",
+						CurrentAction: "pending",
+						StartedAt:     &now,
+					})
+				}
+
 				pm.currentProcess = &ProcessStatus{
 					ID:                 processID,
 					Status:             "running",
-					StartTime:          time.Now(),
+					StartTime:          now,
+					Providers:          providerStatuses,
 					ProvidersProcessed: providersToProcess,
 					ProvidersRemoved:   providersToRemove,
 				}
@@ -254,6 +267,54 @@ func (pm *ProcessManager) GetRecentProcesses(limit int) []*ProcessStatus {
 	}
 
 	return result
+}
+
+// GetProviderStatus returns the status of a specific provider within the current process
+func (pm *ProcessManager) GetProviderStatus(providerName string) *ProviderStatus {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	if pm.currentProcess == nil {
+		return nil
+	}
+
+	for _, ps := range pm.currentProcess.Providers {
+		if ps.Name == providerName {
+			return ps
+		}
+	}
+	return nil
+}
+
+// UpdateProviderStatus updates the status of a specific provider within the current process
+func (pm *ProcessManager) UpdateProviderStatus(providerName string, status string, currentAction string, pageCurrent int, pageTotal int, bytesTransferred int64, retryCount int, lastError *string, entriesProcessed int) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if pm.currentProcess == nil {
+		return
+	}
+
+	now := time.Now()
+	for _, ps := range pm.currentProcess.Providers {
+		if ps.Name == providerName {
+			ps.Status = status
+			ps.CurrentAction = currentAction
+			ps.PageCurrent = pageCurrent
+			ps.PageTotal = pageTotal
+			ps.BytesTransferred = bytesTransferred
+			ps.RetryCount = retryCount
+			ps.LastError = lastError
+			ps.EntriesProcessed = entriesProcessed
+			if status == "running" && ps.StartedAt == nil {
+				ps.StartedAt = &now
+			}
+			if status == "done" || status == "error" || status == "skipped" {
+				ps.CompletedAt = &now
+			}
+			return
+		}
+	}
 }
 
 // ResetForTesting resets the process manager state (for tests only)

--- a/features/providers/services/provider_service.go
+++ b/features/providers/services/provider_service.go
@@ -179,12 +179,15 @@ func (s *ProviderProcessService) GetProcessStatus(ctx context.Context, processID
 }
 
 func (s *ProviderProcessService) ListProcesses(ctx context.Context) ([]*providers.ProcessStatus, error) {
+	startTime := time.Now()
+
 	// Get processes from database
 	dbStatuses, err := s.repo.ListProcesses(ctx)
 	if err != nil {
 		log.Err(err).Msg("Failed to list processes")
 		return nil, ErrListProcesses
 	}
+	dbElapsed := time.Since(startTime)
 
 	// Create a map of DB process IDs for quick lookup
 	dbProcessIDs := make(map[string]bool)
@@ -193,8 +196,10 @@ func (s *ProviderProcessService) ListProcesses(ctx context.Context) ([]*provider
 	}
 
 	// Get in-memory processes (current + recent history) from ProcessManager
+	pmStart := time.Now()
 	pm := providers.GetProcessManager()
 	inMemoryProcesses := pm.GetRecentProcesses(50) // Get up to 50 recent processes
+	pmElapsed := time.Since(pmStart)
 
 	// Initialize result as empty slice (not nil) so JSON returns [] instead of null
 	result := make([]*providers.ProcessStatus, 0)
@@ -208,6 +213,16 @@ func (s *ProviderProcessService) ListProcesses(ctx context.Context) ([]*provider
 
 	// Append DB processes
 	result = append(result, dbStatuses...)
+
+	totalElapsed := time.Since(startTime)
+	log.Info().
+		Dur("db_query_time", dbElapsed).
+		Dur("pm_query_time", pmElapsed).
+		Dur("total_time", totalElapsed).
+		Int("in_memory_count", len(inMemoryProcesses)).
+		Int("db_count", len(dbStatuses)).
+		Int("total_count", len(result)).
+		Msg("ListProcesses completed")
 
 	return result, nil
 }

--- a/features/providers/status.go
+++ b/features/providers/status.go
@@ -2,13 +2,29 @@ package providers
 
 import "time"
 
+// ProviderStatus holds the detailed status of a single provider within a process.
+type ProviderStatus struct {
+	Name            string     `json:"name"`
+	Status          string     `json:"status"` // "running", "done", "error", "pending", "skipped"
+	CurrentAction   string     `json:"current_action"` // "fetching_page", "parsing", "writing_db", "completed", "failed"
+	PageCurrent     int        `json:"page_current,omitempty"`
+	PageTotal       int        `json:"page_total,omitempty"`
+	BytesTransferred int64     `json:"bytes_transferred"`
+	RetryCount      int        `json:"retry_count"`
+	LastError       *string    `json:"last_error,omitempty"`
+	EntriesProcessed int       `json:"entries_processed"`
+	StartedAt       *time.Time `json:"started_at,omitempty"`
+	CompletedAt     *time.Time `json:"completed_at,omitempty"`
+}
+
 // ProcessStatus holds the status of a provider processing task.
 type ProcessStatus struct {
-	ID                 string    `json:"id"`
-	Status             string    `json:"status"` // "running", "completed", "failed"
-	StartTime          time.Time `json:"start_time"`
-	EndTime            time.Time `json:"end_time"`
-	ProvidersProcessed []string  `json:"providers_processed,omitempty"`
-	ProvidersRemoved   []string  `json:"providers_removed,omitempty"`
-	Error              string    `json:"error,omitempty"`
+	ID                 string           `json:"id"`
+	Status             string           `json:"status"` // "running", "completed", "failed"
+	StartTime          time.Time        `json:"start_time"`
+	EndTime            time.Time        `json:"end_time"`
+	Providers          []*ProviderStatus `json:"providers,omitempty"`
+	ProvidersProcessed []string         `json:"providers_processed,omitempty"`
+	ProvidersRemoved   []string         `json:"providers_removed,omitempty"`
+	Error              string           `json:"error,omitempty"`
 }


### PR DESCRIPTION
## Summary

Add detailed per-provider status tracking to /provider/processes endpoint.

### Changes

#### 1. ProviderStatus struct (features/providers/status.go)
New struct with fields:
- name, status (running/done/error/pending/skipped)
- current_action (fetching_page/parsing/writing_db/completed/failed)
- page_current, page_total, bytes_transferred
- retry_count, last_error, entries_processed
- started_at, completed_at

#### 2. ProcessManager updates (features/providers/process_manager.go)
- TryStartProcess: initializes per-provider status entries
- GetProviderStatus / UpdateProviderStatus methods
- Auto-sets timestamps on state transitions

#### 3. Process tracking (features/providers/process.go)
- processProvider: updates status at each phase
- processMultiPageProvider: updates page progress

#### 4. Performance logging (features/providers/services/provider_service.go)
- Timing logs: db_query_time, pm_query_time, total_time

### Files Changed
- features/providers/status.go (+16)
- features/providers/process_manager.go (+47)
- features/providers/process.go (+50)
- features/providers/services/provider_service.go (+15)

### Test
go build ./... PASS

### Status
Build: PASS