### PR TITLE
fix(blocklistde): add IPv6 support and populate IP column

### DIFF
--- a/features/providers/blocklistde/provider.go
+++ b/features/providers/blocklistde/provider.go
@@ -135,11 +135,6 @@ func parseBlocklistDeData(
 			skippedCount++
 			continue
 		}
-		if parsed.To4() == nil {
-			log.Debug().Str("ip", ip).Msg("IPv6 detected — skipping")
-			skippedCount++
-			continue
-		}
 
 		category := resolveCategory(ip, sets)
 
@@ -150,6 +145,7 @@ func parseBlocklistDeData(
 
 		entry.Host = ip
 		entry.Domain = ip
+		entry.IP = ip
 		entry.SourceURL = sourceURL
 
 		collector.Submit(entry)


### PR DESCRIPTION
## Summary
- Removed  check that was skipping IPv6 addresses
- Added  to populate the IP column for both IPv4 and IPv6
- Host/Domain/IP fields are now all set appropriately

## Changes
- : Removed IPv6 skip filter, added IP column population

## Test
-  passed